### PR TITLE
Add missing TrackedConfig field to Canary status CRD

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -941,6 +941,11 @@ spec:
                     - Failed
                     - Terminating
                     - Terminated
+                trackedConfigs:
+                  description: TrackedConfig of this canary
+                  additionalProperties:
+                    type: string
+                  type: object
                 canaryWeight:
                   description: Traffic weight routed to canary
                   type: number

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -941,6 +941,11 @@ spec:
                     - Failed
                     - Terminating
                     - Terminated
+                trackedConfigs:
+                  description: TrackedConfig of this canary
+                  additionalProperties:
+                    type: string
+                  type: object
                 canaryWeight:
                   description: Traffic weight routed to canary
                   type: number

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -941,6 +941,11 @@ spec:
                     - Failed
                     - Terminating
                     - Terminated
+                trackedConfigs:
+                  description: TrackedConfig of this canary
+                  additionalProperties:
+                    type: string
+                  type: object
                 canaryWeight:
                   description: Traffic weight routed to canary
                   type: number

--- a/test/workloads/deployment.yaml
+++ b/test/workloads/deployment.yaml
@@ -31,6 +31,12 @@ spec:
       - name: podinfod
         image: stefanprodan/podinfo:3.1.0
         imagePullPolicy: IfNotPresent
+        env:
+          - name: PODINFO_SECRET_VALUE
+            valueFrom:
+              secretKeyRef:
+                name: podinfo-secret
+                key: value
         ports:
           - name: http
             containerPort: 9898

--- a/test/workloads/init.sh
+++ b/test/workloads/init.sh
@@ -19,5 +19,6 @@ kubectl apply -k ${REPO_ROOT}/kustomize/tester
 kubectl -n test rollout status deployment/flagger-loadtester
 
 echo '>>> Deploy podinfo'
+kubectl apply -f ${REPO_ROOT}/test/workloads/secret.yaml
 kubectl apply -f ${REPO_ROOT}/test/workloads/deployment.yaml
 kubectl apply -f ${REPO_ROOT}/test/workloads/daemonset.yaml

--- a/test/workloads/secret.yaml
+++ b/test/workloads/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: podinfo-secret
+  namespace: test
+stringData:
+  value: s3cr3t


### PR DESCRIPTION
Fix: https://github.com/fluxcd/flagger/issues/780

When using secret with Canary deployment, Canary deployment repeated again and again.
This PullRequest is fixing this issue.