### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.6.1
+
+**Release date:** 2021-01-19
+
+This release extends the support for Istio's `HTTPMatchRequest` and
+comes with a regression bug fix to secrets and configmaps tracking.
+
+#### Improvements
+
+- Update HTTPMatchRequest to match Istio's definitions
+  [#777](https://github.com/fluxcd/flagger/pull/777)
+- e2e: Update Istio to v1.8.2 and Contour to v1.11.0
+  [#778](https://github.com/fluxcd/flagger/pull/778)
+
+#### Fixes
+
+- Add missing TrackedConfig field to Canary status CRD
+  [#781](https://github.com/fluxcd/flagger/pull/781)
+  
 ## 1.6.0
 
 **Release date:** 2021-01-05

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.6.0
+        image: ghcr.io/fluxcd/flagger:1.6.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.6.0
-appVersion: 1.6.0
+version: 1.6.1
+appVersion: 1.6.1
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.6.0
+  tag: 1.6.1
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.6.0
+    newTag: 1.6.1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.6.0"
+var VERSION = "1.6.1"
 var REVISION = "unknown"


### PR DESCRIPTION
This release extends the support for Istio's `HTTPMatchRequest` and comes with a regression bug fix to secrets and configmaps tracking.