### PR TITLE
add custom metadata in event webhook

### DIFF
--- a/docs/gitbook/usage/webhooks.md
+++ b/docs/gitbook/usage/webhooks.md
@@ -66,6 +66,9 @@ Spec:
       - name: "send to Slack"
         type: event
         url: http://event-recevier.notifications/slack
+        metadata:
+          environment: "test"
+          cluster: "flagger-test"
 ```
 
 > **Note** that the sum of all rollout webhooks timeouts should be lower than the analysis interval.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.14.1
+	golang.org/x/tools v0.1.0 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.15
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -351,6 +352,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -368,6 +370,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -397,6 +400,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -449,6 +454,8 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGgVFN1DM1/wz4aoGOA5qS8=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -52,7 +52,7 @@ func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template
 	for _, canaryWebhook := range r.GetAnalysis().Webhooks {
 		if canaryWebhook.Type == flaggerv1.EventHook {
 			webhookOverride = true
-			err := CallEventWebhook(r, canaryWebhook.URL, fmt.Sprintf(template, args...), eventType)
+			err := CallEventWebhook(r, canaryWebhook, fmt.Sprintf(template, args...), eventType)
 			if err != nil {
 				c.logger.With("canary", fmt.Sprintf("%s.%s", r.Name, r.Namespace)).Errorf("error sending event to webhook: %s", err)
 			}
@@ -60,7 +60,11 @@ func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template
 	}
 
 	if c.eventWebhook != "" && !webhookOverride {
-		err := CallEventWebhook(r, c.eventWebhook, fmt.Sprintf(template, args...), eventType)
+		hook := flaggerv1.CanaryWebhook{
+			Name: "events",
+			URL:  c.eventWebhook,
+		}
+		err := CallEventWebhook(r, hook, fmt.Sprintf(template, args...), eventType)
 		if err != nil {
 			c.logger.With("canary", fmt.Sprintf("%s.%s", r.Name, r.Namespace)).Errorf("error sending event to webhook: %s", err)
 		}

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -115,9 +115,9 @@ func CallEventWebhook(r *flaggerv1.Canary, w flaggerv1.CanaryWebhook, message, e
 
 	if w.Metadata != nil {
 		for key, value := range *w.Metadata {
-                        if _, ok := payload.Metadata[key]; ok {
-                            continue
-                        }
+			if _, ok := payload.Metadata[key]; ok {
+				continue
+			}
 			payload.Metadata[key] = value
 		}
 	}

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -99,7 +99,7 @@ func CallWebhook(name string, namespace string, phase flaggerv1.CanaryPhase, w f
 	return callWebhook(w.URL, payload, w.Timeout)
 }
 
-func CallEventWebhook(r *flaggerv1.Canary, webhook, message, eventtype string) error {
+func CallEventWebhook(r *flaggerv1.Canary, w flaggerv1.CanaryWebhook, message, eventtype string) error {
 	t := time.Now()
 
 	payload := flaggerv1.CanaryWebhookPayload{
@@ -113,5 +113,13 @@ func CallEventWebhook(r *flaggerv1.Canary, webhook, message, eventtype string) e
 		},
 	}
 
-	return callWebhook(webhook, payload, "5s")
+	if w.Metadata != nil {
+		for key, value := range *w.Metadata {
+                        if _, ok := payload.Metadata[key]; ok {
+                            continue
+                        }
+			payload.Metadata[key] = value
+		}
+	}
+	return callWebhook(w.URL, payload, "5s")
 }

--- a/pkg/controller/webhook_test.go
+++ b/pkg/controller/webhook_test.go
@@ -101,7 +101,10 @@ func TestCallEventWebhook(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer ts.Close()
-
+	hook := flaggerv1.CanaryWebhook{
+		Name: "event",
+		URL:  ts.URL,
+	}
 	canary := &flaggerv1.Canary{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      canaryName,
@@ -112,7 +115,7 @@ func TestCallEventWebhook(t *testing.T) {
 		},
 	}
 
-	err := CallEventWebhook(canary, ts.URL, canaryMessage, canaryEventType)
+	err := CallEventWebhook(canary, hook, canaryMessage, canaryEventType)
 	require.NoError(t, err)
 }
 
@@ -126,7 +129,10 @@ func TestCallEventWebhookStatusCode(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
-
+	hook := flaggerv1.CanaryWebhook{
+		Name: "event",
+		URL:  ts.URL,
+	}
 	canary := &flaggerv1.Canary{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      canaryName,
@@ -137,6 +143,6 @@ func TestCallEventWebhookStatusCode(t *testing.T) {
 		},
 	}
 
-	err := CallEventWebhook(canary, ts.URL, canaryMessage, canaryEventType)
+	err := CallEventWebhook(canary, hook, canaryMessage, canaryEventType)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This PR adds support for setting custom metadata in event webhook.  I think this would be helpful when managing multiple Kubernetes cluster and single notification system.   