### PR TITLE
Suffix only the podAntiAffinity values that match the deployment name

### DIFF
--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -19,6 +19,7 @@ package canary
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -274,8 +275,12 @@ func TestDeploymentController_AntiAffinity(t *testing.T) {
 
 		value := depPrimary.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.LabelSelector.MatchExpressions[0].Values[0]
 		assert.Equal(t, "podinfo-primary", value)
+		value = depPrimary.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[1].PodAffinityTerm.LabelSelector.MatchExpressions[0].Values[0]
+		assert.False(t, strings.HasSuffix(value, "-primary"))
 
 		value = depPrimary.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchExpressions[0].Values[0]
 		assert.Equal(t, "podinfo-primary", value)
+		value = depPrimary.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[1].LabelSelector.MatchExpressions[0].Values[0]
+		assert.False(t, strings.HasSuffix(value, "-primary"))
 	})
 }

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -571,6 +571,18 @@ func newDeploymentControllerTest(dc deploymentConfigs) *appsv1.Deployment {
 										},
 									},
 								},
+								{
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:    "app",
+													Values: []string{"arbitrary-app"},
+												},
+											},
+										},
+									},
+								},
 							},
 							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 								{
@@ -579,6 +591,16 @@ func newDeploymentControllerTest(dc deploymentConfigs) *appsv1.Deployment {
 											{
 												Key:    "app",
 												Values: []string{"podinfo"},
+											},
+										},
+									},
+								},
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:    "app",
+												Values: []string{"arbitrary-app"},
 											},
 										},
 									},


### PR DESCRIPTION
Fixed so that only the values matching the canary name are suffixed under podAntiAffinity

Closes: #804