### PR TITLE
Rewrite the primary Pod Topology Spread Constraints based on label selector

### DIFF
--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -317,6 +317,8 @@ spec:
                 matchLabels:
                   affinity: podinfo
               topologyKey: topology.kubernetes.io/zone
+```
+
 ## Metrics
 
 #### How does Flagger measure the request success rate and duration?

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -456,6 +456,11 @@ func (c *DeploymentController) scale(cd *flaggerv1.Canary, replicas int32) error
 func (c *DeploymentController) getPrimaryDeploymentTemplateSpec(canaryDep *appsv1.Deployment, refs map[string]ConfigRef) corev1.PodSpec {
 	spec := c.configTracker.ApplyPrimaryConfigs(canaryDep.Spec.Template.Spec, refs)
 
+	// update TopologySpreadConstraints
+	for _, topologySpreadConstraint := range spec.TopologySpreadConstraints {
+		c.appendPrimarySuffixToValuesIfNeeded(topologySpreadConstraint.LabelSelector, canaryDep)
+	}
+
 	// update affinity
 	if affinity := spec.Affinity; affinity != nil {
 		if podAntiAffinity := affinity.PodAntiAffinity; podAntiAffinity != nil {

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -616,6 +616,28 @@ func newDeploymentControllerTest(dc deploymentConfigs) *appsv1.Deployment {
 							},
 						},
 					},
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:    "app",
+										Values: []string{"podinfo"},
+									},
+								},
+							},
+						},
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:    "app",
+										Values: []string{"arbitrary-app"},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds rewrites of label selector values for Pod Topology Spread Constraints, similar to what we already have for PodAntiAffinity.

Fix: #801