### PR TITLE
chart: Added PodDisruptionBudget for the loadtester

### DIFF
--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -1,7 +1,7 @@
 # Flagger load testing service
 
-[Flagger's](https://github.com/fluxcd/flagger) load testing service is based on 
-[rakyll/hey](https://github.com/rakyll/hey) and 
+[Flagger's](https://github.com/fluxcd/flagger) load testing service is based on
+[rakyll/hey](https://github.com/rakyll/hey) and
 [bojand/ghz](https://github.com/bojand/ghz).
 It can be used to generate HTTP and gRPC traffic during canary analysis when configured as a webhook.
 
@@ -50,7 +50,7 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.tag` | Image tag | `<VERSION>`
 `replicaCount` | Desired number of pods | `1`
-`serviceAccountName` | Kubernetes service account name | `none` 
+`serviceAccountName` | Kubernetes service account name | `none`
 `resources.requests.cpu` | CPU requests | `10m`
 `resources.requests.memory` | Memory requests | `64Mi`
 `tolerations` | List of node taints to tolerate | `[]`
@@ -70,6 +70,8 @@ Parameter | Description | Default
 `podPriorityClassName` | PriorityClass name for pod priority configuration | ""
 `securityContext.enabled` | Add securityContext to container | ""
 `securityContext.context` | securityContext to add | ""
+`podDisruptionBudget.enabled` | A PodDisruptionBudget will be created if `true` | `false`
+`podDisruptionBudget.minAvailable` | The minimal number of available replicas that will be set in the PodDisruptionBudget | `1`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 
@@ -87,5 +89,3 @@ helm install flagger/loadtester --name flagger-loadtester -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-

--- a/charts/loadtester/templates/pdb.yaml
+++ b/charts/loadtester/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loadtester.fullname" . }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "loadtester.name" . }}
+{{- end }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -9,7 +9,7 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "8080"
 
-podPriorityClassName: ""  
+podPriorityClassName: ""
 
 logLevel: info
 cmd:
@@ -62,15 +62,15 @@ appmesh:
   - podinfo
   - podinfo-canary
 
-#Istio virtual service and gatway settings. TLS secrets should be in namespace before enbaled it. ( secret format loadtester.fullname ) 
+#Istio virtual service and gatway settings. TLS secrets should be in namespace before enbaled it. ( secret format loadtester.fullname )
 istio:
   enabled: false
   host: flagger-loadtester.flagger
   gateway:
-    enabled: false  
+    enabled: false
   tls:
     enabled: false
-    httpsRedirect: false 
+    httpsRedirect: false
 
 # when enabled, it will add a security context for the loadtester pod
 securityContext:
@@ -79,3 +79,7 @@ securityContext:
     readOnlyRootFilesystem: true
     runAsUser: 100
     runAsGroup: 101
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1


### PR DESCRIPTION
This PR adds the ability to specify a PodDisruptionBudget for the loadtester similar to what we
have for the Flagger operator.

```
> helm template fl loadtester -f loadtester/values.yaml --set podDisruptionBudget.enabled=true
# Source: loadtester/templates/pdb.yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: fl-loadtester
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: loadtester
---
# Source: loadtester/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fl-loadtester
  labels:
    app.kubernetes.io/name: loadtester
    helm.sh/chart: loadtester-0.18.0
    app.kubernetes.io/instance: fl
    app.kubernetes.io/managed-by: Helm
...
```
