### PR TITLE
Fix AWS AppMesh issue when providing multiple backends

### DIFF
--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -119,24 +119,22 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 	}
 
 	backends := make([]appmeshv1.Backend, 0)
-	for _, b := range canary.Spec.Service.Backends {
-		var bk appmeshv1.Backend
-		if strings.HasPrefix(b, "arn:aws") {
-			bk = appmeshv1.Backend{
+	for i := range canary.Spec.Service.Backends {
+		if strings.HasPrefix(canary.Spec.Service.Backends[i], "arn:aws") {
+			backends = append(backends, appmeshv1.Backend{
 				VirtualService: appmeshv1.VirtualServiceBackend{
-					VirtualServiceARN: &b,
+					VirtualServiceARN: &canary.Spec.Service.Backends[i],
 				},
-			}
+			})
 		} else {
-			bk = appmeshv1.Backend{
+			backends = append(backends, appmeshv1.Backend{
 				VirtualService: appmeshv1.VirtualServiceBackend{
 					VirtualServiceRef: &appmeshv1.VirtualServiceReference{
-						Name: b,
+						Name: canary.Spec.Service.Backends[i],
 					},
 				},
-			}
+			})
 		}
-		backends = append(backends, bk)
 	}
 
 	if len(backends) > 0 {


### PR DESCRIPTION
Signed-off-by: Joao Carreira <jddcarreira@gmail.com>

When adding multiple backend (by arn or by virtual service name), while using AWS App Mesh as a provided, Flagger was returning the following error:
```
reconcileVirtualNode failed: VirtualNode test-app-primary update error admission webhook "vvirtualnode.appmesh.k8s.aws" denied the request: VirtualNode-test-app-primary has duplicate VirtualServiceReferenceARNs arn:aws:appmesh:eu-west-1:0000000000:mesh/mymesh/virtualService/api-bar.local
```
This was caused by a wrong usage of `range`, since in a range when targeting the pointer of an element it seems to return the object of the slice and not the object of the element in the slice.
https://golang.org/doc/effective_go#slices

Here's a representation of what was happening:
- https://play.golang.org/p/OUdzwkFjEYZ
- https://www.ardanlabs.com/blog/2013/09/iterating-over-slices-in-go.html

In this MR we make use of the index to access the element of the slice, representing each backend.