### PR TITLE
chart: Add pull secret for Prometheus deployment

### DIFF
--- a/charts/flagger/templates/prometheus.yaml
+++ b/charts/flagger/templates/prometheus.yaml
@@ -255,7 +255,10 @@ spec:
               mountPath: /etc/prometheus
             - name: data-volume
               mountPath: /prometheus/data
-
+      {{- if .Values.prometheus.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.prometheus.pullSecret }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -125,6 +125,7 @@ prometheus:
   # to be used with ingress controllers
   install: false
   image: docker.io/prom/prometheus:v2.23.0
+  pullSecret:
   retention: 2h
 
 kubeconfigQPS: ""


### PR DESCRIPTION
Prometheus deployment created by the Helm chart is missing a pull secret,
variable is necessary to pull the prometheus image from private a repository

fix: #841