### PR TITLE
linkerd: update prometheus URL based on the latest 2.10 changes

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -31,7 +31,8 @@ Install Flagger for Linkerd:
 kustomize build https://github.com/fluxcd/flagger/kustomize/linkerd?ref=main | kubectl apply -f -
 ```
 
-This deploys Flagger in the `linkerd` namespace and sets the metrics server URL to Linkerd's Prometheus instance.
+This deploys Flagger in the `linkerd` namespace and sets the metrics server URL to linkerd-viz extension's Prometheus instance
+which lives under `linkerd-viz` namespace by default.
 
 If you want to install a specific Flagger release, add the version number to the URL:
 

--- a/kustomize/linkerd/patch.yaml
+++ b/kustomize/linkerd/patch.yaml
@@ -11,7 +11,7 @@ spec:
             - -log-level=info
             - -include-label-prefix=app.kubernetes.io
             - -mesh-provider=linkerd
-            - -metrics-server=http://linkerd-prometheus.linkerd-viz:9090
+            - -metrics-server=http://prometheus.linkerd-viz:9090
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/kustomize/linkerd/patch.yaml
+++ b/kustomize/linkerd/patch.yaml
@@ -11,7 +11,7 @@ spec:
             - -log-level=info
             - -include-label-prefix=app.kubernetes.io
             - -mesh-provider=linkerd
-            - -metrics-server=http://linkerd-prometheus:9090
+            - -metrics-server=http://linkerd-prometheus.linkerd-viz:9090
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/test/linkerd/install.sh
+++ b/test/linkerd/install.sh
@@ -2,20 +2,21 @@
 
 set -o errexit
 
-LINKERD_VER="stable-2.8.1"
+LINKERD_VER="stable-2.10.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin
 
-curl -SsL https://github.com/linkerd/linkerd2/releases/download/${LINKERD_VER}/linkerd2-cli-${LINKERD_VER}-linux > ${REPO_ROOT}/bin/linkerd
+curl -SsL https://github.com/linkerd/linkerd2/releases/download/${LINKERD_VER}/linkerd2-cli-${LINKERD_VER}-linux-amd64 > ${REPO_ROOT}/bin/linkerd
 chmod +x ${REPO_ROOT}/bin/linkerd
 
 echo ">>> Installing Linkerd ${LINKERD_VER}"
 ${REPO_ROOT}/bin/linkerd install | kubectl apply -f -
 ${REPO_ROOT}/bin/linkerd check
 
-kubectl -n linkerd rollout status deployment/linkerd-controller
-kubectl -n linkerd rollout status deployment/linkerd-proxy-injector
+echo ">>> Installing Linkerd Viz"
+${REPO_ROOT}/bin/linkerd viz install | kubectl apply -f -
+${REPO_ROOT}/bin/linkerd viz check
 
 echo '>>> Installing Flagger'
 kubectl apply -k ${REPO_ROOT}/kustomize/linkerd

--- a/test/linkerd/test-canary.sh
+++ b/test/linkerd/test-canary.sh
@@ -15,7 +15,7 @@ metadata:
 spec:
   provider:
     type: prometheus
-    address: http://linkerd-prometheus.linkerd:9090
+    address: http://prometheus.linkerd-viz:9090
   query: |
     histogram_quantile(
         0.99,


### PR DESCRIPTION
In Linkerd 2.10, The Prometheus instance moved into the `viz`
extension which is installed separately from the core
control-plane. This means that the prometheus now exists in
the `linkerd-viz` namespace by default unless overriden.

This PR updates the URl to reflect the same

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>