### PR TITLE
e2e fix: Update Contour installer

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,9 +28,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: "v0.10.0"
-          image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
       - name: Build container image
         run: |
           docker build -t test/flagger:latest .

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.10.0"
+          image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
       - name: Build container image
         run: |
           docker build -t test/flagger:latest .

--- a/test/contour/install.sh
+++ b/test/contour/install.sh
@@ -2,13 +2,13 @@
 
 set -o errexit
 
-CONTOUR_VER="v1.11.0"
+CONTOUR_VER="release-1.13"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin
 
 echo '>>> Installing Contour'
-kubectl apply -f https://projectcontour.io/quickstart/${CONTOUR_VER}/contour.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/${CONTOUR_VER}/examples/render/contour.yaml
 
 kubectl -n projectcontour rollout status deployment/contour
 kubectl -n projectcontour get all

--- a/test/gloo/install.sh
+++ b/test/gloo/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-GLOO_VER="1.6.0"
+GLOO_VER="1.6.13"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin


### PR DESCRIPTION
projectcontour.io went down during the weekend, this PR fixes the e2e tests by downloading the Contour manifests from GitHub.

Other e2e changes:
- update Contour to v1.13
- update Gloo to v1.6.13