### PR TITLE
Add a clarification to the doc pre-requisite namespace

### DIFF
--- a/docs/gitbook/tutorials/kubernetes-blue-green.md
+++ b/docs/gitbook/tutorials/kubernetes-blue-green.md
@@ -13,6 +13,8 @@ Flagger requires a Kubernetes cluster **v1.16** or newer.
 Install Flagger and the Prometheus add-on:
 
 ```bash
+kubectl create ns flagger
+
 helm repo add flagger https://flagger.app
 
 helm upgrade -i flagger flagger/flagger \


### PR DESCRIPTION
The helm install fails if a flagger namespace doesn't already exist.