### PR TITLE
feat: add webhook for manually approving traffic weight increase

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -940,6 +940,7 @@ spec:
                               - post-rollout
                               - event
                               - rollback
+                              - confirm-traffic-increase
                           url:
                             description: URL address of this webhook
                             type: string

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -940,6 +940,7 @@ spec:
                               - post-rollout
                               - event
                               - rollback
+                              - confirm-traffic-increase
                           url:
                             description: URL address of this webhook
                             type: string

--- a/docs/gitbook/usage/webhooks.md
+++ b/docs/gitbook/usage/webhooks.md
@@ -16,6 +16,9 @@ There are several types of hooks:
 * **rollout** hooks are executed during the analysis on each iteration before the metric checks.
   If a rollout hook call fails the canary advancement is paused and eventfully rolled back.
 
+* **confirm-traffic-increase** hooks are executed right before the weight on the canary is increased. The canary
+  advancement is paused until this hook returns HTTP 200.
+
 * **confirm-promotion** hooks are executed before the promotion step.
   The canary promotion is paused until the hooks return HTTP 200.
   While the promotion is paused, Flagger will continue to run the metrics checks and rollout hooks.
@@ -51,6 +54,9 @@ Spec:
         timeout: 15s
         metadata:
           cmd: "hey -z 1m -q 5 -c 2 http://podinfo-canary.test:9898/"
+      - name: "traffic increase gate"
+        type: confirm-traffic-increase
+        url: http://flagger-loadtester.test/gate/approve
       - name: "promotion gate"
         type: confirm-promotion
         url: http://flagger-loadtester.test/gate/approve
@@ -347,7 +353,8 @@ the web-hook will try to call Concord before timing out (Default is 30s).
 ## Manual Gating
 
 For manual approval of a canary deployment you can use the `confirm-rollout` and `confirm-promotion` webhooks.
-The confirmation rollout hooks are executed before the pre-rollout hooks.
+The confirmation rollout hooks are executed before the pre-rollout hooks. For manually approving traffic weight increase,
+you can use the `confirm-traffic-increase` webhook.
 Flagger will halt the canary traffic shifting and analysis until the confirm webhook returns HTTP status 200.
 
 For manual rollback of a canary deployment you can use the `rollback` webhook.

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -314,6 +314,8 @@ const (
 	EventHook HookType = "event"
 	// RollbackHook rollback canary analysis if webhook returns HTTP 200
 	RollbackHook HookType = "rollback"
+	// ConfirmTrafficIncreaseHook increases traffic weight if webhook returns HTTP 200
+	ConfirmTrafficIncreaseHook = "confirm-traffic-increase"
 )
 
 // CanaryWebhook holds the reference to external checks used for canary analysis

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -412,6 +412,12 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 	// strategy: Canary progressive traffic increase
 	if c.nextStepWeight(cd, canaryWeight) > 0 {
+		// run hook only if traffic is not mirrored
+		if !mirrored {
+			if promote := c.runConfirmTrafficIncreaseHooks(cd); !promote {
+				return
+			}
+		}
 		c.runCanary(cd, canaryController, meshRouter, mirrored, canaryWeight, primaryWeight, maxWeight)
 	}
 


### PR DESCRIPTION
### What is this change?
This PR adds a new webhook for manually approving traffic weight increase. The logic is similar to `confirm-promotion`, but for approving traffic weight increase.

### Why is this needed?

Organizations have use-cases where they would like to wait indefinitely before the traffic weight on the canary increases. For example, we may want to hold at 10% weight, run some checks, smoke/conformance tests or manually verify metrics to ensure that the canary is reliable. This is especially useful in orgs which are in the process of making metrics and SLOs mature. 
(Similar to how [argo rollouts works](https://argoproj.github.io/argo-rollouts/getting-started/#1-deploying-a-rollout))

Although we could use the `rollout` webhook for this, it wouldn't wait indefinitely and eventually fail as a non-200 response from the webhook would count as an error.

### Example

```yaml
- name: "confirm traffic increase"
  type: confirm-traffic-increase
  url: http://flagger-loadtester.test/gate/check
```
Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>