### PR TITLE
feat: make gloo upstream discovery configurable

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -82,6 +82,9 @@ spec:
                 provider:
                   description: Traffic managent provider
                   type: string
+                glooUpstreamDiscoveryNs:
+                  description: Namespace where Gloo Upstreams are installed
+                  type: string
                 metricsServer:
                   description: Prometheus URL
                   type: string

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -85,6 +85,9 @@ spec:
                 metricsServer:
                   description: Prometheus URL
                   type: string
+                glooUpstreamDiscoveryNs:
+                  description: Namespace where Gloo Upstreams are installed
+                  type: string
                 progressDeadlineSeconds:
                   description: Deployment progress deadline
                   type: number

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -66,6 +66,10 @@ type CanarySpec struct {
 	// +optional
 	MetricsServer string `json:"metricsServer,omitempty"`
 
+	// GlooUpstreamDiscoveryNs is the namespace where Gloo Upstreams are created
+	// +optional
+	GlooUpstreamDiscoveryNs string `json:"glooUpstreamDiscoveryNs,omitempty"`
+
 	// TargetRef references a target resource
 	TargetRef CrossNamespaceObjectReference `json:"targetRef"`
 


### PR DESCRIPTION
## What is this change?

This PR makes Gloo Upstream discovery namespace configurable by providing a `"spec.glooUpstreamDiscoveryNs"` field. Currently, the upstream discovery namespace is hard-coded to `"gloo-system"` and may leave some restrictions on users who are trying to integrate Flagger with Gloo.

## What problem does this solve?

From the many [deployment patterns](https://docs.solo.io/gloo-edge/latest/introduction/architecture/deployment_arch/) gloo offers, we've employed the [bounded-context API gateway](https://docs.solo.io/gloo-edge/latest/introduction/architecture/deployment_arch/#bounded-context-api-gateway), meaning each namespace may have its own installation of Gloo, and can hence hold `VirtualService`s and `RouteTable`s within its own namespace. 

With the current implementation of Flagger, we're restricted to deploying Gloo `Upstream`s in a single namespace which seems restrictive. Moreover, users following even the single API Gateway pattern may have gloo installed in a namespace other than `"gloo-system"`. With this PR, users may now configure which namespace to reference `Upstream`s from, within the Canary spec itself.

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>