### PR TITLE
Update traefik-progressive-delivery.md

### DIFF
--- a/docs/gitbook/tutorials/traefik-progressive-delivery.md
+++ b/docs/gitbook/tutorials/traefik-progressive-delivery.md
@@ -15,7 +15,7 @@ helm repo add traefik https://helm.traefik.io/traefik
 kubectl create ns traefik
 helm upgrade -i traefik traefik/traefik \
 --namespace traefik \
---set additionalArguments="--metrics.prometheus=true"
+--set additionalArguments="{--metrics.prometheus=true}"
 ```
 
 Install Flagger and the Prometheus add-on in the same namespace as Traefik:


### PR DESCRIPTION
Use curly braces to specify an array value in helm set.

The latest versions of the chart need to have the additional arguments specified as a list or they error out:

```
Error: template: traefik/templates/_podtemplate.tpl:199:20: executing "traefik.podTemplate" at <.>: range can't iterate over --metrics.prometheus=true
```