### PR TITLE
Add offerup to the organizations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ List of organizations using Flagger:
 * [eLife](https://elifesciences.org/)
 * [Trendhim](https://www.trendhim.com)
 * [Sinch](https://www.sinch.com)
+* [OfferUp](https://www.offerup.com)
 
 If you are using Flagger, please submit a PR to add your organization to the list!
 


### PR DESCRIPTION
Proposing to add [OfferUp](https://www.offerup.com) to the list of organizations that use flagger.