### PR TITLE
* Update URL for linkerd-prometheus in linkerd-viz namespace

### DIFF
--- a/kustomize/linkerd/patch.yaml
+++ b/kustomize/linkerd/patch.yaml
@@ -11,7 +11,7 @@ spec:
             - -log-level=info
             - -include-label-prefix=app.kubernetes.io
             - -mesh-provider=linkerd
-            - -metrics-server=http://prometheus.linkerd-viz:9090
+            - -metrics-server=http://linkerd-prometheus.linkerd-viz:9090
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I noticed that the URL for the prometheus instance deployed with `linkerd-viz` was not set. I think the name of the service was changed in the Linkerd repo after this patch file was updated.

Signed-off-by: Charles Pretzer <charles@charlespretzer.com>