### PR TITLE
fix: Remove alerting for confirm-traffic-increase webhook

### DIFF
--- a/pkg/controller/scheduler_hooks.go
+++ b/pkg/controller/scheduler_hooks.go
@@ -30,7 +30,6 @@ func (c *Controller) runConfirmTrafficIncreaseHooks(canary *flaggerv1.Canary) bo
 			if err != nil {
 				c.recordEventWarningf(canary, "Halt %s.%s advancement waiting for traffic increase approval %s",
 					canary.Name, canary.Namespace, webhook.Name)
-				c.alert(canary, "Canary traffic increase is waiting for approval.", false, flaggerv1.SeverityWarn)
 				return false
 			}
 			c.recordEventInfof(canary, "Confirm-traffic-increase check %s passed", webhook.Name)

--- a/test-svc.yaml
+++ b/test-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: podinfo
+  namespace: test
+  labels:
+      env: production
+      test: label
+spec:
+  type: LoadBalancer
+  selector:
+      app: podinfo
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http


### PR DESCRIPTION
#### What is the issue?

The `confirm-traffic-increase` webhook is used to manually approve each time you want to increase the weight on the Canary. When alerting is enabled along with this webhook, way too many alerts are generated while the Canary is waits for this webhooks to suceed. This, multiplied with the number of steps your Canary takes could potentially lead to a spam of alerts.

#### What is the fix?

This PR removes alerting for `confirm-traffic-webhook`. Even if we do find a way to alert only once per step, it becomes too noisy if the number of steps your Canary takes increases.

#### Alternatives considered

If there's a chance that users find alerting useful for this webhook, we should instead find a way to mute alerts for specific webhooks. That way, users have the flexibility of muting alerts from Flagger for the `confirm-traffic-increase` webhook.
See - https://github.com/fluxcd/flagger/pull/887

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>