### PR TITLE
Fix Deployment of Flagger loadtester to include the correct label

### DIFF
--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ include "loadtester.name" . }}
+        app.kubernetes.io/name: {{ include "loadtester.name" . }}
       annotations:
         appmesh.k8s.aws/ports: "444"
         {{- if .Values.podAnnotations }}
@@ -29,7 +30,7 @@ spec:
       {{- end }}
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
-      {{- end }}           
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
@@ -69,7 +70,7 @@ spec:
           {{- if .Values.env }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
-          {{- end }} 
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
The Deployment of the Flagger loadtester did not contain the correct
label app.kubernetes.io/name. This label is used for the Flagger
deployment and it is also used in the PodDisruptionBudget for
the Flagger operator. I added the same label to the Flagger
load tester to make the PodDisruptionBudget work correctly
for the Flagger loadtester.