### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.8.0
+
+**Release date:** 2021-03-23
+
+This release comes with support for the SMI `v1alpha2` and `v1alpha3` TrafficSplit APIs.
+
+For SMI compatible service mesh solutions like Open Service Mesh, Consul Connect or Nginx Service Mesh,
+[Prometheus MetricTemplates](https://docs.flagger.app/usage/metrics#prometheus) can be used to implement
+the request success rate and request duration checks.
+
+The desired SMI version can be set in the Canary object:
+
+```yaml
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: my-canary
+spec:
+  provider: "smi:v1alpha3" # or "smi:v1alpha2"
+```
+
+#### Features
+
+- Implement SMI v1alpha2 and v1alpha3 routers
+  [#896](https://github.com/fluxcd/flagger/pull/896)
+  [#879](https://github.com/fluxcd/flagger/pull/879)
+- Add alerting HTTP/S proxy option
+  [#872](https://github.com/fluxcd/flagger/pull/872)
+- Add option to mute alerts generated from webhooks
+  [#887](https://github.com/fluxcd/flagger/pull/887)
+
+#### Fixes
+
+- Scale up canary on confirm rollout
+  [#878](https://github.com/fluxcd/flagger/pull/878)
+
 ## 1.7.0
 
 **Release date:** 2021-03-23

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.7.0
+        image: ghcr.io/fluxcd/flagger:1.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.7.0
-appVersion: 1.7.0
+version: 1.8.0
+appVersion: 1.8.0
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.7.0
+  tag: 1.8.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: loadtester
-version: 0.18.0
+version: 0.19.0
 appVersion: 0.18.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/docs/gitbook/usage/webhooks.md
+++ b/docs/gitbook/usage/webhooks.md
@@ -377,6 +377,17 @@ The `/gate/halt` returns HTTP 403 thus blocking the rollout.
 If you have notifications enabled, Flagger will post a message to
 Slack or MS Teams if a canary rollout is waiting for approval.
 
+The notifications can be disabled with:
+
+```yaml
+  analysis:
+    webhooks:
+      - name: "gate"
+        type: confirm-rollout
+        url: http://flagger-loadtester.test/gate/halt
+        muteAlert: true
+```
+
 Change the URL to `/gate/approve` to start the canary analysis:
 
 ```yaml

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.7.0
+    newTag: 1.8.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.7.0"
+var VERSION = "1.8.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with support for the SMI `v1alpha2` and `v1alpha3` TrafficSplit APIs.

For SMI compatible service mesh solutions like Open Service Mesh, Consul Connect or Nginx Service Mesh, [Prometheus MetricTemplates](https://docs.flagger.app/usage/metrics#prometheus) can be used to implement the request success rate and request duration checks.

The desired SMI version can be set in the Canary object:

```yaml
apiVersion: flagger.app/v1beta1
kind: Canary
metadata:
  name: my-canary
spec:
  provider: "smi:v1alpha3" # or "smi:v1alpha2" or "smi:v1alpha1"
```

#### Features

- Implement SMI v1alpha2 and v1alpha3 routers
- Add alerting HTTP/S proxy option
- Add option to mute alerts generated from webhooks

#### Fixes

- Scale up canary on confirm rollout