### PR TITLE
style: rename CanaryWaitingPromotion to CanaryPhaseWaitingPromotion

### DIFF
--- a/pkg/apis/flagger/v1beta1/status.go
+++ b/pkg/apis/flagger/v1beta1/status.go
@@ -47,8 +47,8 @@ const (
 	CanaryPhaseWaiting CanaryPhase = "Waiting"
 	// CanaryPhaseProgressing means the canary analysis is underway
 	CanaryPhaseProgressing CanaryPhase = "Progressing"
-	// CanaryWaitingPromotion means the canary promotion is paused (waiting for confirmation to proceed)
-	CanaryWaitingPromotion CanaryPhase = "WaitingPromotion"
+	// CanaryPhaseWaitingPromotion means the canary promotion is paused (waiting for confirmation to proceed)
+	CanaryPhaseWaitingPromotion CanaryPhase = "WaitingPromotion"
 	// CanaryPhasePromoting means the canary analysis is finished and the primary spec has been updated
 	CanaryPhasePromoting CanaryPhase = "Promoting"
 	// CanaryPhaseFinalising means the canary promotion is finished and traffic has been routed back to primary

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -207,7 +207,7 @@ func MakeStatusConditions(cd *flaggerv1.Canary,
 	case flaggerv1.CanaryPhaseWaiting:
 		status = corev1.ConditionUnknown
 		message = "Waiting for approval."
-	case flaggerv1.CanaryWaitingPromotion:
+	case flaggerv1.CanaryPhaseWaitingPromotion:
 		status = corev1.ConditionUnknown
 		message = "Waiting for approval."
 	case flaggerv1.CanaryPhaseProgressing:

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -311,7 +311,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 	// check if we should rollback
 	if cd.Status.Phase == flaggerv1.CanaryPhaseProgressing ||
 		cd.Status.Phase == flaggerv1.CanaryPhaseWaiting ||
-		cd.Status.Phase == flaggerv1.CanaryWaitingPromotion {
+		cd.Status.Phase == flaggerv1.CanaryPhaseWaitingPromotion {
 		if ok := c.runRollbackHooks(cd, cd.Status.Phase); ok {
 			c.recordEventWarningf(cd, "Rolling back %s.%s manual webhook invoked", cd.Name, cd.Namespace)
 			c.alert(cd, "Rolling back manual webhook invoked", false, flaggerv1.SeverityWarn)
@@ -752,7 +752,7 @@ func (c *Controller) shouldAdvance(canary *flaggerv1.Canary, canaryController ca
 		canary.Status.Phase == flaggerv1.CanaryPhaseInitializing ||
 		canary.Status.Phase == flaggerv1.CanaryPhaseProgressing ||
 		canary.Status.Phase == flaggerv1.CanaryPhaseWaiting ||
-		canary.Status.Phase == flaggerv1.CanaryWaitingPromotion ||
+		canary.Status.Phase == flaggerv1.CanaryPhaseWaitingPromotion ||
 		canary.Status.Phase == flaggerv1.CanaryPhasePromoting ||
 		canary.Status.Phase == flaggerv1.CanaryPhaseFinalising {
 		return true, nil
@@ -778,7 +778,7 @@ func (c *Controller) shouldAdvance(canary *flaggerv1.Canary, canaryController ca
 func (c *Controller) checkCanaryStatus(canary *flaggerv1.Canary, canaryController canary.Controller, shouldAdvance bool) bool {
 	c.recorder.SetStatus(canary, canary.Status.Phase)
 	if canary.Status.Phase == flaggerv1.CanaryPhaseProgressing ||
-		canary.Status.Phase == flaggerv1.CanaryWaitingPromotion ||
+		canary.Status.Phase == flaggerv1.CanaryPhaseWaitingPromotion ||
 		canary.Status.Phase == flaggerv1.CanaryPhasePromoting ||
 		canary.Status.Phase == flaggerv1.CanaryPhaseFinalising {
 		return true
@@ -826,7 +826,7 @@ func (c *Controller) checkCanaryStatus(canary *flaggerv1.Canary, canaryControlle
 
 func (c *Controller) hasCanaryRevisionChanged(canary *flaggerv1.Canary, canaryController canary.Controller) bool {
 	if canary.Status.Phase == flaggerv1.CanaryPhaseProgressing ||
-		canary.Status.Phase == flaggerv1.CanaryWaitingPromotion {
+		canary.Status.Phase == flaggerv1.CanaryPhaseWaitingPromotion {
 		if diff, _ := canaryController.HasTargetChanged(canary); diff {
 			return true
 		}

--- a/pkg/controller/scheduler_hooks.go
+++ b/pkg/controller/scheduler_hooks.go
@@ -81,8 +81,8 @@ func (c *Controller) runConfirmPromotionHooks(canary *flaggerv1.Canary, canaryCo
 		if webhook.Type == flaggerv1.ConfirmPromotionHook {
 			err := CallWebhook(canary.Name, canary.Namespace, flaggerv1.CanaryPhaseProgressing, webhook)
 			if err != nil {
-				if canary.Status.Phase != flaggerv1.CanaryWaitingPromotion {
-					if err := canaryController.SetStatusPhase(canary, flaggerv1.CanaryWaitingPromotion); err != nil {
+				if canary.Status.Phase != flaggerv1.CanaryPhaseWaitingPromotion {
+					if err := canaryController.SetStatusPhase(canary, flaggerv1.CanaryPhaseWaitingPromotion); err != nil {
 						c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).Errorf("%v", err)
 					}
 					c.recordEventWarningf(canary, "Halt %s.%s advancement waiting for promotion approval %s",


### PR DESCRIPTION
Rename `CanaryWaitingPromotion` to `CanaryPhaseWaitingPromotion` to be more consistent with the existing `CanaryPhase`s.

Signed-off-by: Olivier Michaelis <38879457+oliviermichaelis@users.noreply.github.com>