### PR TITLE
Adjusted Nginx ingress canary headers on init and promotion

### DIFF
--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -213,12 +213,18 @@ func (i *IngressRouter) makeAnnotations(annotations map[string]string) map[strin
 	res := make(map[string]string)
 	for k, v := range annotations {
 		if !strings.Contains(k, i.GetAnnotationWithPrefix("canary")) &&
-			!strings.Contains(k, "kubectl.kubernetes.io/last-applied-configuration") {
+			!strings.Contains(k, "kubectl.kubernetes.io/last-applied-configuration") &&
+			!strings.Contains(k, i.GetAnnotationWithPrefix("canary-weight")) &&
+			!strings.Contains(k, i.GetAnnotationWithPrefix("canary-by-cookie")) &&
+			!strings.Contains(k, i.GetAnnotationWithPrefix("canary-by-header")) &&
+			!strings.Contains(k, i.GetAnnotationWithPrefix("canary-by-header-value")) &&
+			!strings.Contains(k, i.GetAnnotationWithPrefix("canary-by-header-pattern")) {
 			res[k] = v
 		}
 	}
 
-	res[i.GetAnnotationWithPrefix("canary")] = "false"
+	res[i.GetAnnotationWithPrefix("canary")] = "true"
+	res[i.GetAnnotationWithPrefix("canary-weight")] = "0"
 
 	return res
 }

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -42,13 +42,15 @@ func TestIngressRouter_Reconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	canaryAn := "custom.ingress.kubernetes.io/canary"
+	canaryWeightAn := "custom.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
 	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test initialisation
-	assert.Equal(t, "false", inCanary.Annotations[canaryAn])
+	assert.Equal(t, "true", inCanary.Annotations[canaryAn])
+	assert.Equal(t, "0", inCanary.Annotations[canaryWeightAn])
 }
 
 func TestIngressRouter_GetSetRoutes(t *testing.T) {
@@ -94,7 +96,8 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	// test promotion
-	assert.Equal(t, "false", inCanary.Annotations[canaryAn])
+	assert.Equal(t, "true", inCanary.Annotations[canaryAn])
+	assert.Equal(t, "0", inCanary.Annotations[canaryWeightAn])
 }
 
 func TestIngressRouter_ABTest(t *testing.T) {

--- a/test/nginx/install.sh
+++ b/test/nginx/install.sh
@@ -14,6 +14,7 @@ helm upgrade -i ingress-nginx ingress-nginx/ingress-nginx --version=${NGINX_HELM
 --wait \
 --namespace ingress-nginx \
 --set controller.metrics.enabled=true \
+--set controller.admissionWebhooks.enabled=true \
 --set controller.podAnnotations."prometheus\.io/scrape"=true \
 --set controller.podAnnotations."prometheus\.io/port"=10254 \
 --set controller.service.type=NodePort

--- a/test/nginx/test-canary.sh
+++ b/test/nginx/test-canary.sh
@@ -195,6 +195,30 @@ done
 
 echo '✔ Canary promotion test passed'
 
+echo 'Testing original ingress update after canary promotion to pass validation webhook'
+
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: podinfo
+  namespace: test
+  labels:
+    app: podinfo
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: app.example.com
+      http:
+        paths:
+          - backend:
+              serviceName: podinfo
+              servicePort: 80
+EOF
+
+echo '✔ Original ingress update with validation webhook passed'
+
 cat <<EOF | kubectl apply -f -
 apiVersion: flagger.app/v1beta1
 kind: Canary


### PR DESCRIPTION
Adjusted canary headers after canary deployment is promoted
It resolves [validation webhook issue](https://github.com/fluxcd/flagger/issues/787) 