### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,31 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.9.0
+
+**Release date:** 2021-05-14
+
+This release comes with improvements to the [Gloo Edge](https://docs.flagger.app/tutorials/gloo-progressive-delivery) integration.
+
+Starting with this version, Flagger no longer requires Gloo discovery to be enabled.
+Flagger generated the Gloo upstream objects on its own and optionally it can use an
+existing upstream (specified with `.spec.upstreamRef`) as a template. 
+
+#### Features
+
+- Gloo: Create gloo upstreams from non-discovered services
+  [#894](https://github.com/fluxcd/flagger/pull/894)
+- Gloo Upstream Ref for Upstream Config
+  [#908](https://github.com/fluxcd/flagger/pull/908)
+
+#### Improvements
+
+- Adjusted Nginx ingress canary headers on init and promotion
+  [#907](https://github.com/fluxcd/flagger/pull/907)
+
 ## 1.8.0
 
-**Release date:** 2021-03-23
+**Release date:** 2021-04-29
 
 This release comes with support for the SMI `v1alpha2` and `v1alpha3` TrafficSplit APIs.
 

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.8.0
+        image: ghcr.io/fluxcd/flagger:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.8.0
-appVersion: 1.8.0
+version: 1.9.0
+appVersion: 1.9.0
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.8.0
+  tag: 1.9.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.8.0
+    newTag: 1.9.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.8.0"
+var VERSION = "1.9.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with improvements to the [Gloo Edge](https://docs.flagger.app/tutorials/gloo-progressive-delivery) integration.

Starting with this version, Flagger no longer requires Gloo discovery to be enabled.
Flagger generated the Gloo upstream objects on its own and optionally it can use an
existing upstream (specified with `.spec.upstreamRef`) as a template. 