### PR TITLE
ConfigTracker: Scan envFrom in init-containers

### DIFF
--- a/pkg/canary/config_tracker.go
+++ b/pkg/canary/config_tracker.go
@@ -135,6 +135,7 @@ func (ct *ConfigTracker) GetTargetConfigs(cd *flaggerv1.Canary) (map[string]Conf
 		}
 		vs = targetDep.Spec.Template.Spec.Volumes
 		cs = targetDep.Spec.Template.Spec.Containers
+		cs = append(cs, targetDep.Spec.Template.Spec.InitContainers...)
 	case "DaemonSet":
 		targetDae, err := ct.KubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 		if err != nil {
@@ -142,6 +143,7 @@ func (ct *ConfigTracker) GetTargetConfigs(cd *flaggerv1.Canary) (map[string]Conf
 		}
 		vs = targetDae.Spec.Template.Spec.Volumes
 		cs = targetDae.Spec.Template.Spec.Containers
+		cs = append(cs, targetDae.Spec.Template.Spec.InitContainers...)
 	default:
 		return nil, fmt.Errorf("TargetRef.Kind invalid: %s", cd.Spec.TargetRef.Kind)
 	}

--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -57,6 +57,16 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configPrimaryVolName := depPrimary.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name
 		assert.Equal(t, "podinfo-config-vol-primary", configPrimaryVolName)
 
+		configPrimaryInit, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, configMap.Data["color"], configPrimaryInit.Data["color"])
+		}
+
+		configPrimaryInitEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-all-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, configMap.Data["color"], configPrimaryInitEnv.Data["color"])
+		}
+
 		configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimary.Data["color"])
@@ -122,6 +132,16 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 
 		configPrimaryVolName := daePrimary.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name
 		assert.Equal(t, "podinfo-config-vol-primary", configPrimaryVolName)
+
+		configPrimaryInit, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, configMap.Data["color"], configPrimaryInit.Data["color"])
+		}
+
+		configPrimaryInitEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-all-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, configMap.Data["color"], configPrimaryInitEnv.Data["color"])
+		}
 
 		configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
@@ -190,6 +210,16 @@ func TestConfigTracker_Secrets(t *testing.T) {
 				depPrimary.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName)
 		}
 
+		secretPrimaryInit, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInit.Data["apiKey"]))
+		}
+
+		secretPrimaryInitEnv, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-all-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInitEnv.Data["apiKey"]))
+		}
+
 		secretPrimary, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimary.Data["apiKey"]))
@@ -253,6 +283,16 @@ func TestConfigTracker_Secrets(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, "podinfo-secret-vol-primary",
 				daePrimary.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName)
+		}
+
+		secretPrimaryInit, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInit.Data["apiKey"]))
+		}
+
+		secretPrimaryInitEnv, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-all-env-primary", metav1.GetOptions{})
+		if assert.NoError(t, err) {
+			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInitEnv.Data["apiKey"]))
 		}
 
 		secretPrimary, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-env-primary", metav1.GetOptions{})

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -59,12 +59,16 @@ func newDaemonSetFixture(dc daemonsetConfigs) daemonSetControllerFixture {
 		newDaemonSetControllerTestConfigProjected(),
 		newDaemonSetControllerTestConfigMapTrackerEnabled(),
 		newDaemonSetControllerTestConfigMapTrackerDisabled(),
+		newDaemonSetControllerTestConfigMapInit(),
+		newDaemonSetControllerTestConfigMapInitEnv(),
 		newDaemonSetControllerTestSecret(),
 		newDaemonSetControllerTestSecretEnv(),
 		newDaemonSetControllerTestSecretVol(),
 		newDaemonSetControllerTestSecretProjected(),
 		newDaemonSetControllerTestSecretTrackerEnabled(),
 		newDaemonSetControllerTestSecretTrackerDisabled(),
+		newDaemonSetControllerTestSecretInit(),
+		newDaemonSetControllerTestSecretInitEnv(),
 	)
 
 	logger, _ := logger.NewLogger("debug")
@@ -136,6 +140,32 @@ func newDaemonSetControllerTestConfigMapEnv() *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo-config-all-env",
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
+func newDaemonSetControllerTestConfigMapInit() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-init-env",
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
+func newDaemonSetControllerTestConfigMapInitEnv() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-init-all-env",
 		},
 		Data: map[string]string{
 			"color": "red",
@@ -286,6 +316,34 @@ func newDaemonSetControllerTestSecretTrackerDisabled() *corev1.Secret {
 	}
 }
 
+func newDaemonSetControllerTestSecretInit() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-init-env",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
+func newDaemonSetControllerTestSecretInitEnv() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-init-all-env",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
 func newDaemonSetControllerTestCanary(dc daemonsetConfigs) *flaggerv1.Canary {
 	cd := &flaggerv1.Canary{
 		TypeMeta: metav1.TypeMeta{APIVersion: flaggerv1.SchemeGroupVersion.String()},
@@ -324,6 +382,50 @@ func newDaemonSetControllerTestPodInfo(dc daemonsetConfigs) *appsv1.DaemonSet {
 					},
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name: "PODINFO_UI_COLOR",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "podinfo-config-init-env",
+											},
+											Key: "color",
+										},
+									},
+								},
+								{
+									Name: "API_KEY",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "podinfo-secret-init-env",
+											},
+											Key: "apiKey",
+										},
+									},
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "podinfo-config-init-all-env",
+										},
+									},
+								},
+								{
+									SecretRef: &corev1.SecretEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "podinfo-secret-init-all-env",
+										},
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "podinfo",


### PR DESCRIPTION
Currently, the ConfigTracker is not supported scanning initContainer's environments.
this PR supports that. it is useful when we want to switch the path to the data at the timing of starting initContainer.

How can I add tests to scan envFrom in initContainer?
I guess I would add the initContainer spec to the struct returned by the `newDeploymentControllerTest` method in `deployment_fixture_test.go`.