### PR TITLE
Upgrade Ingress to networking.k8s.io/v1

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.11.0"
+          image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
       - name: Build container image
         run: |
           docker build -t test/flagger:latest .

--- a/docs/gitbook/tutorials/nginx-progressive-delivery.md
+++ b/docs/gitbook/tutorials/nginx-progressive-delivery.md
@@ -6,7 +6,7 @@ This guide shows you how to use the NGINX ingress controller and Flagger to auto
 
 ## Prerequisites
 
-Flagger requires a Kubernetes cluster **v1.16** or newer and NGINX ingress **v0.41** or newer.
+Flagger requires a Kubernetes cluster **v1.19** or newer and NGINX ingress **v0.46** or newer.
 
 Install the NGINX ingress controller with Helm v3:
 
@@ -59,7 +59,7 @@ helm upgrade -i flagger-loadtester flagger/loadtester \
 Create an ingress definition (replace `app.example.com` with your own domain):
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: podinfo
@@ -70,12 +70,16 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: app.example.com
+    - host: "app.example.com"
       http:
         paths:
-          - backend:
-              serviceName: podinfo
-              servicePort: 80
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: podinfo
+                port:
+                  number: 80
 ```
 
 Save the above resource as podinfo-ingress.yaml and then apply it:
@@ -101,7 +105,7 @@ spec:
     name: podinfo
   # ingress reference
   ingressRef:
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: podinfo
   # HPA reference (optional)

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -45,7 +45,7 @@ func TestIngressRouter_Reconcile(t *testing.T) {
 	canaryWeightAn := "custom.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
-	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
+	inCanary, err := router.kubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test initialisation
@@ -78,7 +78,7 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	canaryWeightAn := "prefix1.nginx.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
-	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
+	inCanary, err := router.kubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test rollout
@@ -92,7 +92,7 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	err = router.SetRoutes(mocks.ingressCanary, p, c, m)
 	require.NoError(t, err)
 
-	inCanary, err = router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
+	inCanary, err = router.kubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test promotion
@@ -175,7 +175,7 @@ func TestIngressRouter_ABTest(t *testing.T) {
 		canaryAn := router.GetAnnotationWithPrefix("canary")
 
 		canaryName := fmt.Sprintf("%s-canary", table.makeCanary().Spec.IngressRef.Name)
-		inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
+		inCanary, err := router.kubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), canaryName, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// test initialisation

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -415,7 +415,7 @@ func newTestCanaryIngress() *flaggerv1.Canary {
 			},
 			IngressRef: &flaggerv1.CrossNamespaceObjectReference{
 				Name:       "podinfo",
-				APIVersion: "extensions/v1beta1",
+				APIVersion: "networking.k8s.io/v1",
 				Kind:       "Ingress",
 			},
 			Service: flaggerv1.CanaryService{
@@ -437,9 +437,9 @@ func newTestCanaryIngress() *flaggerv1.Canary {
 	return cd
 }
 
-func newTestIngress() *v1beta1.Ingress {
-	return &v1beta1.Ingress{
-		TypeMeta: metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String()},
+func newTestIngress() *netv1.Ingress {
+	return &netv1.Ingress{
+		TypeMeta: metav1.TypeMeta{APIVersion: netv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo",
@@ -447,18 +447,22 @@ func newTestIngress() *v1beta1.Ingress {
 				"kubernetes.io/ingress.class": "nginx",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
 				{
 					Host: "app.example.com",
-					IngressRuleValue: v1beta1.IngressRuleValue{
-						HTTP: &v1beta1.HTTPIngressRuleValue{
-							Paths: []v1beta1.HTTPIngressPath{
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
 								{
 									Path: "/",
-									Backend: v1beta1.IngressBackend{
-										ServiceName: "podinfo",
-										ServicePort: intstr.FromInt(9898),
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "podinfo",
+											Port: netv1.ServiceBackendPort{
+												Number: 9898,
+											},
+										},
 									},
 								},
 							},

--- a/test/nginx/install.sh
+++ b/test/nginx/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-NGINX_HELM_VERSION=3.15.2 # ingress v0.41.2
+NGINX_HELM_VERSION=3.31.0 # ingress v0.46.0
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin

--- a/test/nginx/test-canary.sh
+++ b/test/nginx/test-canary.sh
@@ -8,7 +8,7 @@ set -o errexit
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: podinfo
@@ -19,12 +19,16 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: app.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: podinfo
-              servicePort: 80
+  - host: "app.example.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: podinfo
+            port:
+              number: 80
 EOF
 
 echo '>>> Create metric templates'
@@ -98,7 +102,7 @@ spec:
     kind: Deployment
     name: podinfo
   ingressRef:
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: podinfo
   progressDeadlineSeconds: 60
@@ -198,7 +202,7 @@ echo '✔ Canary promotion test passed'
 echo 'Testing original ingress update after canary promotion to pass validation webhook'
 
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: podinfo
@@ -209,12 +213,16 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-    - host: app.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: podinfo
-              servicePort: 80
+  - host: "app.example.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: podinfo
+            port:
+              number: 80
 EOF
 
 echo '✔ Original ingress update with validation webhook passed'
@@ -231,7 +239,7 @@ spec:
     kind: Deployment
     name: podinfo
   ingressRef:
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: podinfo
   progressDeadlineSeconds: 60

--- a/test/skipper/kustomization.yaml
+++ b/test/skipper/kustomization.yaml
@@ -32,7 +32,7 @@ patches:
               $patch: delete
             containers:
               - name: skipper-ingress
-                image: registry.opensource.zalan.do/pathfinder/skipper:v0.13.61
+                image: registry.opensource.zalan.do/teapot/skipper:v0.13.61
                 ports:
                   - name: metrics-port
                     containerPort: 9911

--- a/test/skipper/kustomization.yaml
+++ b/test/skipper/kustomization.yaml
@@ -3,9 +3,9 @@ kind: Kustomization
 resources:
   - ../../kustomize/base/prometheus/
   - ../../kustomize/base/flagger/
-  - https://raw.githubusercontent.com/zalando/skipper/v0.11.140/docs/kubernetes/deploy/deployment/rbac.yaml
-  - https://raw.githubusercontent.com/zalando/skipper/v0.11.140/docs/kubernetes/deploy/deployment/service.yaml
-  - https://raw.githubusercontent.com/zalando/skipper/v0.11.140/docs/kubernetes/deploy/deployment/deployment.yaml
+  - https://raw.githubusercontent.com/zalando/skipper/v0.13.61/docs/kubernetes/deploy/deployment/rbac.yaml
+  - https://raw.githubusercontent.com/zalando/skipper/v0.13.61/docs/kubernetes/deploy/deployment/service.yaml
+  - https://raw.githubusercontent.com/zalando/skipper/v0.13.61/docs/kubernetes/deploy/deployment/deployment.yaml
   - namespace.yaml
 patchesStrategicMerge:
   - patch.yaml
@@ -32,7 +32,7 @@ patches:
               $patch: delete
             containers:
               - name: skipper-ingress
-                image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.141
+                image: registry.opensource.zalan.do/pathfinder/skipper:v0.13.61
                 ports:
                   - name: metrics-port
                     containerPort: 9911

--- a/test/skipper/test-canary.sh
+++ b/test/skipper/test-canary.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo '>>> Creating ingress'
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: podinfo-ingress
@@ -16,15 +16,19 @@ metadata:
   labels:
     app: podinfo
   annotations:
-    kubernetes.io/ingress.class: skipper
+    kubernetes.io/ingress.class: "skipper"
 spec:
   rules:
-    - host: app.example.com
-      http:
-        paths:
-          - backend:
-              serviceName: podinfo-service
-              servicePort: 80
+  - host: "app.example.com"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: podinfo-service
+            port:
+              number: 80
 EOF
 
 echo '>>> Creating canary'
@@ -41,7 +45,7 @@ spec:
     kind: Deployment
     name: podinfo
   ingressRef:
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: podinfo-ingress
   service:


### PR DESCRIPTION
### ⚠️ Breaking changes

- drop support for Kubernetes Ingress `networking.k8s.io/v1beta1`
- drop support for Kubernetes 1.18 and older versions
- affected integrations: **NGINX** and **Skipper** ingress controllers

### Changes

- use Ingress `networking.k8s.io/v1` for NGINX and Skipper routers
- update Ingress guides to `networking.k8s.io/v1`
- update ingress-nginx to v0.46.0 in e2e tests
- update Skipper to v0.13.61 in e2e tests
