### PR TITLE
add Graphite info to docs

### DIFF
--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -12,7 +12,7 @@ and running conformance tests.
 Flagger implements several deployment strategies (Canary releases, A/B testing, Blue/Green mirroring)
 using a service mesh (App Mesh, Istio, Linkerd)
 or an ingress controller (Contour, Gloo, NGINX, Skipper, Traefik) for traffic routing.
-For release analysis, Flagger can query Prometheus, Datadog, New Relic or CloudWatch
+For release analysis, Flagger can query Prometheus, Datadog, New Relic, CloudWatch or Graphite
 and for alerting it uses Slack, MS Teams, Discord and Rocket.
 
 ![Flagger overview diagram](https://raw.githubusercontent.com/fluxcd/flagger/main/docs/diagrams/flagger-overview.png)

--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -467,7 +467,7 @@ histogram_quantile(0.99,
 
 #### Can I use custom metrics?
 
-The analysis can be extended with metrics provided by Prometheus, Datadog and AWS CloudWatch.
+The analysis can be extended with metrics provided by Prometheus, Datadog, AWS CloudWatch, New Relic and Graphite.
 For more details on how custom metrics can be used please read the [metrics docs](usage/metrics.md).
 
 ## Istio routing


### PR DESCRIPTION
This adds mention of the Graphite metrics provider to a few places in the Flagger documentation where its mention was previously absent.