### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.11.0
+
+**Release date:** 2021-06-01
+
+**Breaking change:** the minimum supported version of Kubernetes is v1.19.0.
+
+This release comes with support for Kubernetes Ingress `networking.k8s.io/v1`.
+The Ingress from `networking.k8s.io/v1beta1` is no longer supported,
+affected integrations: **NGINX** and **Skipper** ingress controllers.
+
+#### Improvements
+
+- Upgrade Ingress to networking.k8s.io/v1
+  [#917](https://github.com/fluxcd/flagger/pull/917)
+- Update Kubernetes manifests to rbac.authorization.k8s.io/v1
+  [#920](https://github.com/fluxcd/flagger/pull/920)
+
 ## 1.10.0
 
 **Release date:** 2021-05-28

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.10.0
+        image: ghcr.io/fluxcd/flagger:1.11.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.10.0
-appVersion: 1.10.0
+version: 1.11.0
+appVersion: 1.11.0
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.10.0
+  tag: 1.11.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.10.0
+    newTag: 1.11.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.10.0"
+var VERSION = "1.11.0"
 var REVISION = "unknown"


### PR DESCRIPTION
⚠️ **Breaking change:** the minimum supported version of Kubernetes is v1.19.0.

This release comes with support for Kubernetes Ingress `networking.k8s.io/v1`.
The Ingress from `networking.k8s.io/v1beta1` is no longer supported, affected integrations: **NGINX** and **Skipper** ingress controllers.