### PR TITLE
gloo: copy labels from upstream

### DIFF
--- a/docs/gitbook/tutorials/gloo-progressive-delivery.md
+++ b/docs/gitbook/tutorials/gloo-progressive-delivery.md
@@ -160,6 +160,8 @@ spec:
           cmd: "hey -z 2m -q 5 -c 2 -host app.example.com http://gateway-proxy.gloo-system"
 ```
 
+*Note: when using upstreamRef the following fields are copied over from the original upstream: `Labels, SslConfig, CircuitBreakers, ConnectionConfig, UseHttp2, InitialStreamWindowSize`*
+
 Save the above resource as podinfo-canary.yaml and then apply it:
 
 ```bash

--- a/pkg/apis/gloo/gloo/v1/types.go
+++ b/pkg/apis/gloo/gloo/v1/types.go
@@ -18,6 +18,7 @@ type Upstream struct {
 
 type UpstreamSpec struct {
 	Kube                        *KubeUpstream         `json:"kube,omitempty"`
+	Labels                      map[string]string     `json:"Labels,omitempty"`
 	SslConfig                   *UpstreamSslConfig    `json:"sslConfig,omitempty"`
 	CircuitBreakers             *CircuitBreakerConfig `json:"circuitBreakers,omitempty"`
 	ConnectionConfig            *ConnectionConfig     `json:"connectionConfig,omitempty"`

--- a/pkg/apis/gloo/gloo/v1/types.go
+++ b/pkg/apis/gloo/gloo/v1/types.go
@@ -18,7 +18,7 @@ type Upstream struct {
 
 type UpstreamSpec struct {
 	Kube                        *KubeUpstream         `json:"kube,omitempty"`
-	Labels                      map[string]string     `json:"Labels,omitempty"`
+	Labels                      map[string]string     `json:"labels,omitempty"`
 	SslConfig                   *UpstreamSslConfig    `json:"sslConfig,omitempty"`
 	CircuitBreakers             *CircuitBreakerConfig `json:"circuitBreakers,omitempty"`
 	ConnectionConfig            *ConnectionConfig     `json:"connectionConfig,omitempty"`

--- a/pkg/apis/gloo/gloo/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/gloo/gloo/v1/zz_generated.deepcopy.go
@@ -294,6 +294,13 @@ func (in *UpstreamSpec) DeepCopyInto(out *UpstreamSpec) {
 		*out = new(KubeUpstream)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SslConfig != nil {
 		in, out := &in.SslConfig, &out.SslConfig
 		*out = new(UpstreamSslConfig)

--- a/pkg/router/gloo.go
+++ b/pkg/router/gloo.go
@@ -38,10 +38,11 @@ import (
 
 // GlooRouter is managing Gloo route tables
 type GlooRouter struct {
-	kubeClient    kubernetes.Interface
-	glooClient    clientset.Interface
-	flaggerClient clientset.Interface
-	logger        *zap.SugaredLogger
+	kubeClient         kubernetes.Interface
+	glooClient         clientset.Interface
+	flaggerClient      clientset.Interface
+	logger             *zap.SugaredLogger
+	includeLabelPrefix []string
 }
 
 // Reconcile creates or updates the Gloo Edge route table
@@ -294,14 +295,7 @@ func (gr *GlooRouter) getGlooUpstreamKubeService(canary *flaggerv1.Canary, svc *
 		Selector:         svc.Spec.Selector,
 	}
 
-	upstreamLabels := make(map[string]string)
-	if upstreamSpec.Labels != nil {
-		for k, v := range upstreamSpec.Labels { // Order not specified
-			if _, ok := upstreamLabels[k]; !ok {
-				upstreamLabels[k] = v
-			}
-		}
-	}
+	upstreamLabels := includeLabelsByPrefix(upstreamSpec.Labels, gr.includeLabelPrefix)
 
 	return &gloov1.Upstream{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/router/util.go
+++ b/pkg/router/util.go
@@ -1,0 +1,19 @@
+package router
+
+import (
+	"strings"
+)
+
+func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []string) map[string]string {
+	filteredLabels := make(map[string]string)
+	for key, value := range labels {
+		for _, includeLabelPrefix := range includeLabelPrefixes {
+			if includeLabelPrefix == "*" || strings.HasPrefix(key, includeLabelPrefix) {
+				filteredLabels[key] = value
+				break
+			}
+		}
+	}
+
+	return filteredLabels
+}

--- a/pkg/router/util_test.go
+++ b/pkg/router/util_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncludeLabelsByPrefix(t *testing.T) {
+	labels := map[string]string{
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
+	}
+	includeLabelPrefix := []string{"foo", "lor"}
+
+	filteredLabels := includeLabelsByPrefix(labels, includeLabelPrefix)
+
+	assert.Equal(t, filteredLabels, map[string]string{
+		"foo":   "foo-value",
+		"lorem": "ipsum",
+		// bar excluded
+	})
+}
+
+func TestIncludeLabelsByPrefixWithWildcard(t *testing.T) {
+	labels := map[string]string{
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
+	}
+	includeLabelPrefix := []string{"*"}
+
+	filteredLabels := includeLabelsByPrefix(labels, includeLabelPrefix)
+
+	assert.Equal(t, filteredLabels, map[string]string{
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
+	})
+}


### PR DESCRIPTION
Copy the Labels over from the upstream as well as config values. This ensures that gatekeeper or OPA validations can pass.