### PR TITLE
fix: Require SMI TrafficSplit Service and Weight

### DIFF
--- a/pkg/apis/smi/v1alpha2/traffic_split.go
+++ b/pkg/apis/smi/v1alpha2/traffic_split.go
@@ -33,8 +33,8 @@ type TrafficSplitSpec struct {
 
 // TrafficSplitBackend defines a backend
 type TrafficSplitBackend struct {
-	Service string `json:"service,omitempty"`
-	Weight  int    `json:"weight,omitempty"`
+	Service string `json:"service"`
+	Weight  int    `json:"weight"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
In the SMI TrafficSplit spec, Weight and Service are
required values for TrafficSplit Backend.
In flagger's SMI v1alpha2 implementation,
Service and Weight have the omitempty json option.

During canary analysis, flagger initially creates
a SMI TrafficSplit custom resource in which the
canary backend service has a Weight of 0.
The omitempty option causes Go to omit Weight
when it sends the custom resource to Kubernetes.
This throws an error during canary analysis.


Fix: #930

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>