### PR TITLE
App mesh additional listener settings

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -746,6 +746,141 @@ spec:
                                 format: string
                                 type: string
                               type: array
+                    outlierDetection:
+                      description: The outlier detection for the listener
+                      properties:
+                        baseEjectionDuration:
+                          description: The base time that a host is ejected for. The
+                            real time is equal to the base time multiplied by the number
+                            of times the host has been ejected
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        interval:
+                          description: The time interval between ejection analysis sweeps.
+                            This can result in both new ejections as well as hosts being
+                            returned to service
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        maxEjectionPercent:
+                          description: The threshold for the max percentage of outlier
+                            hosts that can be ejected from the load balancing set. maxEjectionPercent=100
+                            means outlier detection can potentially eject all of the
+                            hosts from the upstream service if they are all considered
+                            outliers, leaving the load balancing set with zero hosts
+                          format: int64
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                        maxServerErrors:
+                          description: The threshold for the number of server errors
+                            returned by a given host during an outlier detection interval.
+                            If the server error count meets/exceeds this threshold the
+                            host is ejected. A server error is defined as any HTTP 5xx
+                            response (or the equivalent for gRPC and TCP connections)
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - baseEjectionDuration
+                      - interval
+                      - maxEjectionPercent
+                      - maxServerErrors
+                      type: object
+                    connectionPool:
+                      description: The connection pool settings for the listener
+                      properties:
+                        grpc:
+                          description: Specifies grpc connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        http:
+                          description: Specifies http connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            maxPendingRequests:
+                              description: Represents the number of overflowing requests
+                                after max_connections that an envoy will queue to an
+                                upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                        http2:
+                          description: Specifies http2 connection pool settings for
+                            the virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        tcp:
+                          description: Specifies tcp connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                      type: object
                     apex:
                       description: Metadata to add to the apex service
                       type: object

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -746,6 +746,141 @@ spec:
                                 format: string
                                 type: string
                               type: array
+                    outlierDetection:
+                      description: The outlier detection for the listener
+                      properties:
+                        baseEjectionDuration:
+                          description: The base time that a host is ejected for. The
+                            real time is equal to the base time multiplied by the number
+                            of times the host has been ejected
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        interval:
+                          description: The time interval between ejection analysis sweeps.
+                            This can result in both new ejections as well as hosts being
+                            returned to service
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        maxEjectionPercent:
+                          description: The threshold for the max percentage of outlier
+                            hosts that can be ejected from the load balancing set. maxEjectionPercent=100
+                            means outlier detection can potentially eject all of the
+                            hosts from the upstream service if they are all considered
+                            outliers, leaving the load balancing set with zero hosts
+                          format: int64
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                        maxServerErrors:
+                          description: The threshold for the number of server errors
+                            returned by a given host during an outlier detection interval.
+                            If the server error count meets/exceeds this threshold the
+                            host is ejected. A server error is defined as any HTTP 5xx
+                            response (or the equivalent for gRPC and TCP connections)
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - baseEjectionDuration
+                      - interval
+                      - maxEjectionPercent
+                      - maxServerErrors
+                      type: object
+                    connectionPool:
+                      description: The connection pool settings for the listener
+                      properties:
+                        grpc:
+                          description: Specifies grpc connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        http:
+                          description: Specifies http connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            maxPendingRequests:
+                              description: Represents the number of overflowing requests
+                                after max_connections that an envoy will queue to an
+                                upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                        http2:
+                          description: Specifies http2 connection pool settings for
+                            the virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        tcp:
+                          description: Specifies tcp connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                      type: object
                     apex:
                       description: Metadata to add to the apex service
                       type: object

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -746,6 +746,141 @@ spec:
                                 format: string
                                 type: string
                               type: array
+                    outlierDetection:
+                      description: The outlier detection for the listener
+                      properties:
+                        baseEjectionDuration:
+                          description: The base time that a host is ejected for. The
+                            real time is equal to the base time multiplied by the number
+                            of times the host has been ejected
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        interval:
+                          description: The time interval between ejection analysis sweeps.
+                            This can result in both new ejections as well as hosts being
+                            returned to service
+                          properties:
+                            unit:
+                              description: A unit of time.
+                              enum:
+                              - s
+                              - ms
+                              type: string
+                            value:
+                              description: A number of time units.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                          - unit
+                          - value
+                          type: object
+                        maxEjectionPercent:
+                          description: The threshold for the max percentage of outlier
+                            hosts that can be ejected from the load balancing set. maxEjectionPercent=100
+                            means outlier detection can potentially eject all of the
+                            hosts from the upstream service if they are all considered
+                            outliers, leaving the load balancing set with zero hosts
+                          format: int64
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                        maxServerErrors:
+                          description: The threshold for the number of server errors
+                            returned by a given host during an outlier detection interval.
+                            If the server error count meets/exceeds this threshold the
+                            host is ejected. A server error is defined as any HTTP 5xx
+                            response (or the equivalent for gRPC and TCP connections)
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - baseEjectionDuration
+                      - interval
+                      - maxEjectionPercent
+                      - maxServerErrors
+                      type: object
+                    connectionPool:
+                      description: The connection pool settings for the listener
+                      properties:
+                        grpc:
+                          description: Specifies grpc connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        http:
+                          description: Specifies http connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            maxPendingRequests:
+                              description: Represents the number of overflowing requests
+                                after max_connections that an envoy will queue to an
+                                upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                        http2:
+                          description: Specifies http2 connection pool settings for
+                            the virtual node listener
+                          properties:
+                            maxRequests:
+                              description: Represents the maximum number of inflight
+                                requests that an envoy can concurrently support across
+                                all the hosts in the upstream cluster
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxRequests
+                          type: object
+                        tcp:
+                          description: Specifies tcp connection pool settings for the
+                            virtual node listener
+                          properties:
+                            maxConnections:
+                              description: Represents the maximum number of outbound
+                                TCP connections the envoy can establish concurrently
+                                with all the hosts in the upstream cluster.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - maxConnections
+                          type: object
+                      type: object
                     apex:
                       description: Metadata to add to the apex service
                       type: object

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	appmeshv1beta2 "github.com/fluxcd/flagger/pkg/apis/appmesh/v1beta2"
 	istiov1alpha3 "github.com/fluxcd/flagger/pkg/apis/istio/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -179,6 +180,10 @@ type CanaryService struct {
 	// Backends of the generated App Mesh virtual nodes
 	// +optional
 	Backends []string `json:"backends,omitempty"`
+
+	// Outlier detection for generated App Mesh virtual nodes
+	// +optional
+	OutlierDetection *appmeshv1beta2.OutlierDetection `json:"outlierDetection,omitempty"`
 
 	// Apex is metadata to add to the apex service
 	// +optional

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -185,6 +185,10 @@ type CanaryService struct {
 	// +optional
 	OutlierDetection *appmeshv1beta2.OutlierDetection `json:"outlierDetection,omitempty"`
 
+	// Connection pooling for generated App Mesh virtual nodes
+	// +optional
+	ConnectionPool *appmeshv1beta2.VirtualNodeConnectionPool `json:"connectionPool,omitempty"`
+
 	// Apex is metadata to add to the apex service
 	// +optional
 	Apex *CustomMetadata `json:"apex,omitempty"`

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *CanaryService) DeepCopyInto(out *CanaryService) {
 		*out = new(v1beta2.OutlierDetection)
 		**out = **in
 	}
+	if in.ConnectionPool != nil {
+		in, out := &in.ConnectionPool, &out.ConnectionPool
+		*out = new(v1beta2.VirtualNodeConnectionPool)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Apex != nil {
 		in, out := &in.Apex, &out.Apex
 		*out = new(CustomMetadata)

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1beta2 "github.com/fluxcd/flagger/pkg/apis/appmesh/v1beta2"
 	v1alpha3 "github.com/fluxcd/flagger/pkg/apis/istio/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -368,6 +369,11 @@ func (in *CanaryService) DeepCopyInto(out *CanaryService) {
 		in, out := &in.Backends, &out.Backends
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.OutlierDetection != nil {
+		in, out := &in.OutlierDetection, &out.OutlierDetection
+		*out = new(v1beta2.OutlierDetection)
+		**out = **in
 	}
 	if in.Apex != nil {
 		in, out := &in.Apex, &out.Apex

--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -96,6 +96,7 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 	protocol := ar.getProtocol(canary)
 	timeout := ar.makeListenerTimeout(canary)
 	outlierDetection := ar.getOutlierDetectionPolicy(canary)
+	connectionPool := ar.getConnectionPoolSettings(canary)
 
 	vnSpec := appmeshv1.VirtualNodeSpec{
 		Listeners: []appmeshv1.Listener{
@@ -106,6 +107,7 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 				},
 				Timeout:          timeout,
 				OutlierDetection: outlierDetection,
+				ConnectionPool:   connectionPool,
 			},
 		},
 		ServiceDiscovery: &appmeshv1.ServiceDiscovery{
@@ -603,6 +605,13 @@ func (ar *AppMeshv1beta2Router) gatewayAnnotations(canary *flaggerv1.Canary) map
 func (ar *AppMeshv1beta2Router) getOutlierDetectionPolicy(canary *flaggerv1.Canary) *appmeshv1.OutlierDetection {
 	if canary.Spec.Service.OutlierDetection != nil {
 		return canary.Spec.Service.OutlierDetection
+	}
+	return nil
+}
+
+func (ar *AppMeshv1beta2Router) getConnectionPoolSettings(canary *flaggerv1.Canary) *appmeshv1.VirtualNodeConnectionPool {
+	if canary.Spec.Service.ConnectionPool != nil {
+		return canary.Spec.Service.ConnectionPool
 	}
 	return nil
 }

--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -95,6 +95,7 @@ func (ar *AppMeshv1beta2Router) Reconcile(canary *flaggerv1.Canary) error {
 func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, name string, podSelector string, host string) error {
 	protocol := ar.getProtocol(canary)
 	timeout := ar.makeListenerTimeout(canary)
+	outlierDetection := ar.getOutlierDetectionPolicy(canary)
 
 	vnSpec := appmeshv1.VirtualNodeSpec{
 		Listeners: []appmeshv1.Listener{
@@ -103,7 +104,8 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 					Port:     ar.getContainerPort(canary),
 					Protocol: protocol,
 				},
-				Timeout: timeout,
+				Timeout:          timeout,
+				OutlierDetection: outlierDetection,
 			},
 		},
 		ServiceDiscovery: &appmeshv1.ServiceDiscovery{
@@ -596,6 +598,13 @@ func (ar *AppMeshv1beta2Router) gatewayAnnotations(canary *flaggerv1.Canary) map
 		}
 	}
 	return a
+}
+
+func (ar *AppMeshv1beta2Router) getOutlierDetectionPolicy(canary *flaggerv1.Canary) *appmeshv1.OutlierDetection {
+	if canary.Spec.Service.OutlierDetection != nil {
+		return canary.Spec.Service.OutlierDetection
+	}
+	return nil
 }
 
 func (ar *AppMeshv1beta2Router) Finalize(_ *flaggerv1.Canary) error {

--- a/pkg/router/appmesh_v1beta2_test.go
+++ b/pkg/router/appmesh_v1beta2_test.go
@@ -157,6 +157,28 @@ func TestAppmesv1beta2hRouter_ABTest(t *testing.T) {
 	assert.Equal(t, "test", *vrApex.Spec.Routes[0].HTTPRoute.Match.Headers[0].Match.Exact)
 }
 
+func TestAppmeshv1beta2Router_OutlierDetection(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &AppMeshv1beta2Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		appmeshClient: mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	_, primaryName, _ := mocks.appmeshCanaryWithOutlierDetection.GetServiceNames()
+	err := router.Reconcile(mocks.appmeshCanaryWithOutlierDetection)
+	require.NoError(t, err)
+
+	vn, err := router.appmeshClient.AppmeshV1beta2().VirtualNodes("default").Get(context.TODO(), primaryName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, mocks.appmeshCanaryWithOutlierDetection.Spec.Service.OutlierDetection.MaxServerErrors, vn.Spec.Listeners[0].OutlierDetection.MaxServerErrors)
+	assert.Equal(t, mocks.appmeshCanaryWithOutlierDetection.Spec.Service.OutlierDetection.MaxEjectionPercent, vn.Spec.Listeners[0].OutlierDetection.MaxEjectionPercent)
+	assert.Equal(t, mocks.appmeshCanaryWithOutlierDetection.Spec.Service.OutlierDetection.Interval, vn.Spec.Listeners[0].OutlierDetection.Interval)
+	assert.Equal(t, mocks.appmeshCanaryWithOutlierDetection.Spec.Service.OutlierDetection.BaseEjectionDuration, vn.Spec.Listeners[0].OutlierDetection.BaseEjectionDuration)
+}
+
 func TestAppmeshv1beta2Router_Gateway(t *testing.T) {
 	mocks := newFixture(nil)
 	router := &AppMeshv1beta2Router{

--- a/pkg/router/appmesh_v1beta2_test.go
+++ b/pkg/router/appmesh_v1beta2_test.go
@@ -179,6 +179,26 @@ func TestAppmeshv1beta2Router_OutlierDetection(t *testing.T) {
 	assert.Equal(t, mocks.appmeshCanaryWithOutlierDetection.Spec.Service.OutlierDetection.BaseEjectionDuration, vn.Spec.Listeners[0].OutlierDetection.BaseEjectionDuration)
 }
 
+func TestAppmeshv1beta2Router_ConnectionPool(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &AppMeshv1beta2Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		appmeshClient: mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	_, primaryName, _ := mocks.appmeshCanaryWithConnectionPool.GetServiceNames()
+	err := router.Reconcile(mocks.appmeshCanaryWithConnectionPool)
+	require.NoError(t, err)
+
+	vn, err := router.appmeshClient.AppmeshV1beta2().VirtualNodes("default").Get(context.TODO(), primaryName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, mocks.appmeshCanaryWithConnectionPool.Spec.Service.ConnectionPool.HTTP.MaxConnections, vn.Spec.Listeners[0].ConnectionPool.HTTP.MaxConnections)
+	assert.Equal(t, mocks.appmeshCanaryWithConnectionPool.Spec.Service.ConnectionPool.HTTP.MaxPendingRequests, vn.Spec.Listeners[0].ConnectionPool.HTTP.MaxPendingRequests)
+}
+
 func TestAppmeshv1beta2Router_Gateway(t *testing.T) {
 	mocks := newFixture(nil)
 	router := &AppMeshv1beta2Router{

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	appmeshv1beta2 "github.com/fluxcd/flagger/pkg/apis/appmesh/v1beta2"
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	istiov1alpha1 "github.com/fluxcd/flagger/pkg/apis/istio/common/v1alpha1"
 	istiov1alpha3 "github.com/fluxcd/flagger/pkg/apis/istio/v1alpha3"
@@ -35,14 +36,15 @@ import (
 )
 
 type fixture struct {
-	canary        *flaggerv1.Canary
-	abtest        *flaggerv1.Canary
-	appmeshCanary *flaggerv1.Canary
-	ingressCanary *flaggerv1.Canary
-	kubeClient    kubernetes.Interface
-	meshClient    clientset.Interface
-	flaggerClient clientset.Interface
-	logger        *zap.SugaredLogger
+	canary                            *flaggerv1.Canary
+	abtest                            *flaggerv1.Canary
+	appmeshCanary                     *flaggerv1.Canary
+	appmeshCanaryWithOutlierDetection *flaggerv1.Canary
+	ingressCanary                     *flaggerv1.Canary
+	kubeClient                        kubernetes.Interface
+	meshClient                        clientset.Interface
+	flaggerClient                     clientset.Interface
+	logger                            *zap.SugaredLogger
 }
 
 func newFixture(c *flaggerv1.Canary) fixture {
@@ -52,6 +54,7 @@ func newFixture(c *flaggerv1.Canary) fixture {
 	}
 	abtest := newTestABTest()
 	appmeshCanary := newTestCanaryAppMesh()
+	appmeshCanaryWithOutlierDetection := newTestCanaryAppMeshWithOutlierDetection()
 	ingressCanary := newTestCanaryIngress()
 
 	flaggerClient := fakeFlagger.NewSimpleClientset(
@@ -71,14 +74,15 @@ func newFixture(c *flaggerv1.Canary) fixture {
 
 	logger, _ := logger.NewLogger("debug")
 	return fixture{
-		canary:        canary,
-		abtest:        abtest,
-		appmeshCanary: appmeshCanary,
-		ingressCanary: ingressCanary,
-		kubeClient:    kubeClient,
-		meshClient:    meshClient,
-		flaggerClient: flaggerClient,
-		logger:        logger,
+		canary:                            canary,
+		abtest:                            abtest,
+		appmeshCanary:                     appmeshCanary,
+		appmeshCanaryWithOutlierDetection: appmeshCanaryWithOutlierDetection,
+		ingressCanary:                     ingressCanary,
+		kubeClient:                        kubeClient,
+		meshClient:                        meshClient,
+		flaggerClient:                     flaggerClient,
+		logger:                            logger,
 	}
 }
 
@@ -180,6 +184,64 @@ func newTestCanaryAppMesh() *flaggerv1.Canary {
 					Attempts:      5,
 					PerTryTimeout: "gateway-error",
 					RetryOn:       "5s",
+				},
+			}, Analysis: &flaggerv1.CanaryAnalysis{
+				Threshold:  10,
+				StepWeight: 10,
+				MaxWeight:  50,
+				Metrics: []flaggerv1.CanaryMetric{
+					{
+						Name:      "request-success-rate",
+						Threshold: 99,
+						Interval:  "1m",
+					},
+					{
+						Name:      "request-duration",
+						Threshold: 500,
+						Interval:  "1m",
+					},
+				},
+			},
+		},
+	}
+	return cd
+}
+
+func newTestCanaryAppMeshWithOutlierDetection() *flaggerv1.Canary {
+	cd := &flaggerv1.Canary{
+		TypeMeta: metav1.TypeMeta{APIVersion: flaggerv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "appmesh",
+		},
+		Spec: flaggerv1.CanarySpec{
+			TargetRef: flaggerv1.CrossNamespaceObjectReference{
+				Name:       "podinfo",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			Service: flaggerv1.CanaryService{
+				Port:     9898,
+				MeshName: "global",
+				Hosts:    []string{"*"},
+				Backends: []string{"backend.default"},
+				Timeout:  "30s",
+				Retries: &istiov1alpha3.HTTPRetry{
+					Attempts:      5,
+					PerTryTimeout: "gateway-error",
+					RetryOn:       "5s",
+				},
+				OutlierDetection: &appmeshv1beta2.OutlierDetection{
+					MaxServerErrors: int64(20),
+					Interval: appmeshv1beta2.Duration{
+						Unit:  appmeshv1beta2.DurationUnitMS,
+						Value: 500,
+					},
+					BaseEjectionDuration: appmeshv1beta2.Duration{
+						Unit:  appmeshv1beta2.DurationUnitMS,
+						Value: 1000,
+					},
+					MaxEjectionPercent: int64(80),
 				},
 			}, Analysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,


### PR DESCRIPTION
If merged, these changes will allow for further customization of listener settings for generate virtual nodes -- outlier detection and connection pooling. Left separate from istio `trafficPolicy` to avoid confusion around capabilities.

Resolves: #797

Signed-off-by: Kevin Phillips <kevin.phillips@earnin.com>