### PR TITLE
Remove problematic nulls from Grafana dashboard

### DIFF
--- a/charts/grafana/dashboards/appmesh.json
+++ b/charts/grafana/dashboards/appmesh.json
@@ -1146,7 +1146,6 @@
     "list": [
       {
         "allValue": null,
-        "current": null,
         "datasource": "prometheus",
         "definition": "query_result(sum(envoy_cluster_upstream_rq) by (kubernetes_namespace))",
         "hide": 0,
@@ -1168,7 +1167,6 @@
       },
       {
         "allValue": null,
-        "current": null,
         "datasource": "prometheus",
         "definition": "query_result(sum(envoy_cluster_upstream_rq{kubernetes_namespace=\"$namespace\",app=~\".*-primary\"}) by (app))",
         "hide": 0,
@@ -1190,7 +1188,6 @@
       },
       {
         "allValue": null,
-        "current": null,
         "datasource": "prometheus",
         "definition": "query_result(sum(envoy_cluster_upstream_rq{kubernetes_namespace=\"$namespace\",app!~\".*-primary\"}) by (app))",
         "hide": 0,


### PR DESCRIPTION
Newer Grafana (tested with version 7.5.5) produce errors like this when importing or opening (when passed in through a config file) the current dashboard JSON:
<img width="422" alt="error1" src="https://user-images.githubusercontent.com/2081889/125008389-43b90280-e017-11eb-9079-a83263eca923.png">
This stack trace is subsequently shown in the UI:
<img width="569" alt="error2" src="https://user-images.githubusercontent.com/2081889/125008397-46b3f300-e017-11eb-81da-2874533043ce.png">

I confirmed that the problem exists in Grafana installed by the Helm chart in this project with `--set image.tag=7.5.5` as well as Amazon Managed Service for Grafana (AMG) with Grafana version 7.5.5.

Simply removing the offending `"current": null` pairs seems to make things work okay. I confirmed that the code from this PR can be imported successfully into the Helm-installed Grafana with both versions 7.3.4 (current default) as well as 7.5.5. I also tested that it works as expected in AMG with Grafana version 7.5.5.