### PR TITLE
e2e: Update Traefik to 2.4.9

### DIFF
--- a/docs/gitbook/tutorials/traefik-progressive-delivery.md
+++ b/docs/gitbook/tutorials/traefik-progressive-delivery.md
@@ -13,9 +13,17 @@ Install Traefik with Helm v3:
 ```bash
 helm repo add traefik https://helm.traefik.io/traefik
 kubectl create ns traefik
-helm upgrade -i traefik traefik/traefik \
---namespace traefik \
---set additionalArguments="{--metrics.prometheus=true}"
+
+cat <<EOF | helm upgrade -i traefik traefik/traefik --namespace traefik -f -
+deployment:
+  podAnnotations:
+    prometheus.io/port: "9100"
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+metrics:
+  prometheus:
+    entryPoint: metrics
+EOF
 ```
 
 Install Flagger and the Prometheus add-on in the same namespace as Traefik:


### PR DESCRIPTION
The Prometheus annotations [are misplaced](https://github.com/traefik/traefik-helm-chart/issues/460) in Traefik chart v10.1.1, this PR changes the scraping port to 9100 and sets the annotations on pods.