### PR TITLE
adds support for mounting secrets into the environment for loadtester

### DIFF
--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: loadtester
-version: 0.19.0
+version: 0.19.1
 appVersion: 0.18.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
                 - --spider
                 - http://localhost:8080/healthz
             timeoutSeconds: 5
-          {{- if .Values.envFrom }}
+          {{- if .Values.secrets }}
           envFrom:
-          {{- range $secret := .Values.envFrom }}
+          {{- range $secret := .Values.secrets }}
             - secretRef:
                 name: {{ $secret.name }}
           {{- end }}

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -67,6 +67,13 @@ spec:
                 - --spider
                 - http://localhost:8080/healthz
             timeoutSeconds: 5
+          {{- if .Values.envFrom }}
+          envFrom:
+          {{- range $secret := .Values.envFrom }}
+            - secretRef:
+                name: {{ $secret.name }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.env }}
           env:
             {{- toYaml .Values.env | nindent 12 }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -20,7 +20,8 @@ fullnameOverride: ""
 
 env: []
 
-envFrom:
+# Maps to envFrom in the deployment
+secrets:
   # - name: secret-name
   # - name: another-secret
 

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -20,6 +20,10 @@ fullnameOverride: ""
 
 env: []
 
+envFrom:
+  # - name: secret-name
+  # - name: another-secret
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This PR adds support for for mounting secrets as environment variables using `envFrom`.

Sometimes applications have authentication requirements for their APIs and allowing the loadtester to mount those static keys as environment variables makes it a bit easier (rather than disabling auth within the cluster altogether).