### PR TITLE
Add extra podLabels options to Flagger Helm Chart

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -22,6 +22,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "flagger.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       annotations:
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -160,3 +160,5 @@ istio:
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
+
+podLabels: {}


### PR DESCRIPTION
This allows add extra pod labels to Flagger helm chart.