### PR TITLE
Add support for enableWebsockets flag for Contour HTTPProxy

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -183,6 +183,40 @@ spec:
                     enableWebsockets:
                       description: Allow websocket connections to be used with Contour route
                       type: boolean
+                    responseHeadersPolicy:
+                      type: object
+                      description: The policy for managing response headers during
+                        proxying. Rewriting the 'Host' header is not supported.
+                      properties:
+                        remove:
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          description: Set specifies a list of HTTP header values
+                            that will be set in the HTTP header. If the header does
+                            not exist it will be added, otherwise it will be overwritten
+                            with the new value.
+                          items:
+                            description: HeaderValue represents a header name/value
+                              pair
+                            properties:
+                              name:
+                                description: Name represents a key of a header
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value represents the value of a header
+                                  specified by a key
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -180,6 +180,9 @@ spec:
                       type: array
                       items:
                         type: string
+                    enableWebsockets:
+                      description: Allow websocket connections to be used with Contour route
+                      type: boolean
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -183,6 +183,40 @@ spec:
                     enableWebsockets:
                       description: Allow websocket connections to be used with Contour route
                       type: boolean
+                    responseHeadersPolicy:
+                      type: object
+                      description: The policy for managing response headers during
+                        proxying. Rewriting the 'Host' header is not supported.
+                      properties:
+                        remove:
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          description: Set specifies a list of HTTP header values
+                            that will be set in the HTTP header. If the header does
+                            not exist it will be added, otherwise it will be overwritten
+                            with the new value.
+                          items:
+                            description: HeaderValue represents a header name/value
+                              pair
+                            properties:
+                              name:
+                                description: Name represents a key of a header
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value represents the value of a header
+                                  specified by a key
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -180,6 +180,9 @@ spec:
                       type: array
                       items:
                         type: string
+                    enableWebsockets:
+                      description: Allow websocket connections to be used with Contour route
+                      type: boolean
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/go.sum
+++ b/go.sum
@@ -69,7 +69,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -183,6 +183,40 @@ spec:
                     enableWebsockets:
                       description: Allow websocket connections to be used with Contour route
                       type: boolean
+                    responseHeadersPolicy:
+                      type: object
+                      description: The policy for managing response headers during
+                        proxying. Rewriting the 'Host' header is not supported.
+                      properties:
+                        remove:
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          description: Set specifies a list of HTTP header values
+                            that will be set in the HTTP header. If the header does
+                            not exist it will be added, otherwise it will be overwritten
+                            with the new value.
+                          items:
+                            description: HeaderValue represents a header name/value
+                              pair
+                            properties:
+                              name:
+                                description: Name represents a key of a header
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value represents the value of a header
+                                  specified by a key
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -180,6 +180,9 @@ spec:
                       type: array
                       items:
                         type: string
+                    enableWebsockets:
+                      description: Allow websocket connections to be used with Contour route
+                      type: boolean
                     delegation:
                       description: enable behaving as a delegate VirtualService
                       type: boolean

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -148,6 +148,10 @@ type CanaryService struct {
 	// +optional
 	Delegation bool `json:"delegation,omitempty"`
 
+	// EnableWebsockets attached to the generated Contour HTTPProxy routes
+	// +optional
+	EnableWebsockets bool `json:"enableWebsockets,omitempty"`
+
 	// TrafficPolicy attached to the generated Istio destination rules
 	// +optional
 	TrafficPolicy *istiov1alpha3.TrafficPolicy `json:"trafficPolicy,omitempty"`

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	istiov1alpha3 "github.com/fluxcd/flagger/pkg/apis/istio/v1alpha3"
+	projectcontourv1 "github.com/fluxcd/flagger/pkg/apis/projectcontour/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -151,6 +152,10 @@ type CanaryService struct {
 	// EnableWebsockets attached to the generated Contour HTTPProxy routes
 	// +optional
 	EnableWebsockets bool `json:"enableWebsockets,omitempty"`
+
+	// ResponseHeadersPolicy for the genrated Contour HTTPProxy routes
+	// +optional
+	ResponseHeadersPolicy *projectcontourv1.HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 
 	// TrafficPolicy attached to the generated Istio destination rules
 	// +optional

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta1
 
 import (
 	v1alpha3 "github.com/fluxcd/flagger/pkg/apis/istio/v1alpha3"
+	projectcontourv1 "github.com/fluxcd/flagger/pkg/apis/projectcontour/v1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -331,6 +332,11 @@ func (in *CanaryService) DeepCopyInto(out *CanaryService) {
 		in, out := &in.Hosts, &out.Hosts
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ResponseHeadersPolicy != nil {
+		in, out := &in.ResponseHeadersPolicy, &out.ResponseHeadersPolicy
+		*out = new(projectcontourv1.HeadersPolicy)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TrafficPolicy != nil {
 		in, out := &in.TrafficPolicy, &out.TrafficPolicy

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -89,9 +89,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 		newSpec = contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
 				{
-					Conditions:    cr.makeConditions(canary),
-					TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-					RetryPolicy:   cr.makeRetryPolicy(canary),
+					Conditions:       cr.makeConditions(canary),
+					EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+					TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
 							Name:   primaryName,
@@ -121,8 +122,9 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							Prefix: cr.makePrefix(canary),
 						},
 					},
-					TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-					RetryPolicy:   cr.makeRetryPolicy(canary),
+					EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+					TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
 							Name:   primaryName,
@@ -267,8 +269,9 @@ func (cr *ContourRouter) SetRoutes(
 						Prefix: cr.makePrefix(canary),
 					},
 				},
-				TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-				RetryPolicy:   cr.makeRetryPolicy(canary),
+				EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+				TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+				RetryPolicy:      cr.makeRetryPolicy(canary),
 				Services: []contourv1.Service{
 					{
 						Name:   primaryName,
@@ -298,9 +301,10 @@ func (cr *ContourRouter) SetRoutes(
 		proxy.Spec = contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
 				{
-					Conditions:    cr.makeConditions(canary),
-					TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-					RetryPolicy:   cr.makeRetryPolicy(canary),
+					Conditions:       cr.makeConditions(canary),
+					EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+					TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
 							Name:   primaryName,
@@ -330,8 +334,9 @@ func (cr *ContourRouter) SetRoutes(
 							Prefix: cr.makePrefix(canary),
 						},
 					},
-					TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-					RetryPolicy:   cr.makeRetryPolicy(canary),
+					EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+					TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
 							Name:   primaryName,

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -56,8 +56,9 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 						Prefix: cr.makePrefix(canary),
 					},
 				},
-				TimeoutPolicy: cr.makeTimeoutPolicy(canary),
-				RetryPolicy:   cr.makeRetryPolicy(canary),
+				EnableWebsockets: canary.Spec.Service.EnableWebsockets,
+				TimeoutPolicy:    cr.makeTimeoutPolicy(canary),
+				RetryPolicy:      cr.makeRetryPolicy(canary),
 				Services: []contourv1.Service{
 					{
 						Name:   primaryName,

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -61,10 +61,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 				RetryPolicy:      cr.makeRetryPolicy(canary),
 				Services: []contourv1.Service{
 					{
-						Name:   primaryName,
-						Port:   int(canary.Spec.Service.Port),
-						Weight: uint32(100),
-                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+						Name:                  primaryName,
+						Port:                  int(canary.Spec.Service.Port),
+						Weight:                uint32(100),
+						ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -72,10 +72,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 						},
 					},
 					{
-						Name:   canaryName,
-						Port:   int(canary.Spec.Service.Port),
-						Weight: uint32(0),
-                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+						Name:                  canaryName,
+						Port:                  int(canary.Spec.Service.Port),
+						Weight:                uint32(0),
+						ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -97,10 +97,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
-							Name:   primaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(100),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  primaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(100),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -108,10 +108,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							},
 						},
 						{
-							Name:   canaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(0),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  canaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(0),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -131,10 +131,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
-							Name:   primaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(100),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  primaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(100),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -142,10 +142,10 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							},
 						},
 						{
-							Name:   canaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(0),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  canaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(0),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -280,10 +280,10 @@ func (cr *ContourRouter) SetRoutes(
 				RetryPolicy:      cr.makeRetryPolicy(canary),
 				Services: []contourv1.Service{
 					{
-						Name:   primaryName,
-						Port:   int(canary.Spec.Service.Port),
-						Weight: uint32(primaryWeight),
-                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+						Name:                  primaryName,
+						Port:                  int(canary.Spec.Service.Port),
+						Weight:                uint32(primaryWeight),
+						ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -291,10 +291,10 @@ func (cr *ContourRouter) SetRoutes(
 						},
 					},
 					{
-						Name:   canaryName,
-						Port:   int(canary.Spec.Service.Port),
-						Weight: uint32(canaryWeight),
-                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+						Name:                  canaryName,
+						Port:                  int(canary.Spec.Service.Port),
+						Weight:                uint32(canaryWeight),
+						ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -315,10 +315,10 @@ func (cr *ContourRouter) SetRoutes(
 					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
-							Name:   primaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(primaryWeight),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  primaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(primaryWeight),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -326,10 +326,10 @@ func (cr *ContourRouter) SetRoutes(
 							},
 						},
 						{
-							Name:   canaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(canaryWeight),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  canaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(canaryWeight),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -349,10 +349,10 @@ func (cr *ContourRouter) SetRoutes(
 					RetryPolicy:      cr.makeRetryPolicy(canary),
 					Services: []contourv1.Service{
 						{
-							Name:   primaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(100),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  primaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(100),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -360,10 +360,10 @@ func (cr *ContourRouter) SetRoutes(
 							},
 						},
 						{
-							Name:   canaryName,
-							Port:   int(canary.Spec.Service.Port),
-							Weight: uint32(0),
-                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
+							Name:                  canaryName,
+							Port:                  int(canary.Spec.Service.Port),
+							Weight:                uint32(0),
+							ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -64,6 +64,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 						Name:   primaryName,
 						Port:   int(canary.Spec.Service.Port),
 						Weight: uint32(100),
+                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -74,6 +75,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 						Name:   canaryName,
 						Port:   int(canary.Spec.Service.Port),
 						Weight: uint32(0),
+                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -98,6 +100,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							Name:   primaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(100),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -108,6 +111,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							Name:   canaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(0),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -130,6 +134,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							Name:   primaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(100),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -140,6 +145,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 							Name:   canaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(0),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -277,6 +283,7 @@ func (cr *ContourRouter) SetRoutes(
 						Name:   primaryName,
 						Port:   int(canary.Spec.Service.Port),
 						Weight: uint32(primaryWeight),
+                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -287,6 +294,7 @@ func (cr *ContourRouter) SetRoutes(
 						Name:   canaryName,
 						Port:   int(canary.Spec.Service.Port),
 						Weight: uint32(canaryWeight),
+                        ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -310,6 +318,7 @@ func (cr *ContourRouter) SetRoutes(
 							Name:   primaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(primaryWeight),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -320,6 +329,7 @@ func (cr *ContourRouter) SetRoutes(
 							Name:   canaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(canaryWeight),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),
@@ -342,6 +352,7 @@ func (cr *ContourRouter) SetRoutes(
 							Name:   primaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(100),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -352,6 +363,7 @@ func (cr *ContourRouter) SetRoutes(
 							Name:   canaryName,
 							Port:   int(canary.Spec.Service.Port),
 							Weight: uint32(0),
+                            ResponseHeadersPolicy: canary.Spec.Service.ResponseHeadersPolicy,
 							RequestHeadersPolicy: &contourv1.HeadersPolicy{
 								Set: []contourv1.HeaderValue{
 									cr.makeLinkerdHeaderValue(canary, canaryName),


### PR DESCRIPTION
- Adds support for Contour's `enableWebsockets` boolean to be set in the Canary spec so services can have websocket connections work with Flagger.
- Adds support for `responseHeadersPolicy`

Unblocks https://github.com/fluxcd/flagger/issues/968