### PR TITLE
Fix default Traefik metrics

### DIFF
--- a/docs/gitbook/tutorials/traefik-progressive-delivery.md
+++ b/docs/gitbook/tutorials/traefik-progressive-delivery.md
@@ -303,7 +303,7 @@ spec:
     sum(
       rate(
         traefik_service_request_duration_seconds_bucket{
-          service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
+          exported_service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
           code!="404",
         }[{{ interval }}]
       )
@@ -312,7 +312,7 @@ spec:
     sum(
       rate(
         traefik_service_request_duration_seconds_bucket{
-          service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
+          exported_service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
         }[{{ interval }}]
       )
     ) * 100

--- a/pkg/metrics/observers/traefik.go
+++ b/pkg/metrics/observers/traefik.go
@@ -29,7 +29,7 @@ var traefikQueries = map[string]string{
 	sum(
 		rate(
 			traefik_service_request_duration_seconds_bucket{
-				service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
+				exported_service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
 				code!~"5..",
 				le="+Inf"
 			}[{{ interval }}]
@@ -39,7 +39,7 @@ var traefikQueries = map[string]string{
 	sum(
 		rate(
 			traefik_service_request_duration_seconds_bucket{
-				service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
+				exported_service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd",
 				le="+Inf"
 			}[{{ interval }}]
 		)
@@ -50,7 +50,7 @@ var traefikQueries = map[string]string{
 		sum(
 			rate(
 				traefik_service_request_duration_seconds_bucket{
-					service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd"
+					exported_service=~"{{ namespace }}-{{ target }}-canary-[0-9a-zA-Z-]+@kubernetescrd"
 				}[{{ interval }}]
 			)
 		) by (le)

--- a/pkg/metrics/observers/traefik_test.go
+++ b/pkg/metrics/observers/traefik_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestTraefikObserver_GetRequestSuccessRate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		expected := ` sum( rate( traefik_service_request_duration_seconds_bucket{ service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd", code!~"5..", le="+Inf" }[1m] ) ) / sum( rate( traefik_service_request_duration_seconds_bucket{ service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd", le="+Inf" }[1m] ) ) * 100`
+		expected := ` sum( rate( traefik_service_request_duration_seconds_bucket{ exported_service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd", code!~"5..", le="+Inf" }[1m] ) ) / sum( rate( traefik_service_request_duration_seconds_bucket{ exported_service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd", le="+Inf" }[1m] ) ) * 100`
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			promql := r.URL.Query()["query"][0]
@@ -85,7 +85,7 @@ func TestTraefikObserver_GetRequestSuccessRate(t *testing.T) {
 }
 
 func TestTraefikObserver_GetRequestDuration(t *testing.T) {
-	expected := ` histogram_quantile( 0.99, sum( rate( traefik_service_request_duration_seconds_bucket{ service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd" }[1m] ) ) by (le) )`
+	expected := ` histogram_quantile( 0.99, sum( rate( traefik_service_request_duration_seconds_bucket{ exported_service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd" }[1m] ) ) by (le) )`
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		promql := r.URL.Query()["query"][0]


### PR DESCRIPTION
Fixes `request-success-rate` and `request-duration` default metrics for Traefik. The label is `exported_service` not `service`. I can't pinpoint when this changed but this is happening with Traefik 2.4.13 (chart version `10.1.2`).