### PR TITLE
support volumes/volumeMounts in loadtester chart

### DIFF
--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: loadtester
-version: 0.19.0
+version: 0.19.1
 appVersion: 0.18.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -74,6 +74,15 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{ with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -29,6 +29,9 @@ resources:
     cpu: 10m
     memory: 64Mi
 
+volumes: []
+volumeMounts: []
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Adds support for volumes/volumeMounts for the loadtester chart. Being able to pass more complicated scripts or store JSON payloads (i.e. for testing GraphQL APIs) on disk for the loadtester would be a valuable addition to the existing loadtester functionality.