### PR TITLE
Update providers in e2e tests

### DIFF
--- a/test/contour/install.sh
+++ b/test/contour/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-CONTOUR_VER="release-1.15"
+CONTOUR_VER="release-1.18"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin

--- a/test/istio/install.sh
+++ b/test/istio/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.10.0"
+ISTIO_VER="1.11.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin

--- a/test/linkerd/install.sh
+++ b/test/linkerd/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-LINKERD_VER="stable-2.10.0"
+LINKERD_VER="stable-2.10.2"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin

--- a/test/nginx/install.sh
+++ b/test/nginx/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-NGINX_HELM_VERSION=3.31.0 # ingress v0.46.0
+NGINX_HELM_VERSION=3.36.0 # ingress v0.49.0
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin


### PR DESCRIPTION
Changes:
- Update Istio to v1.11.0
- Update Contour to v1.18
- Update Linkerd to v2.10.2
- Update Ingress NGINX to v0.49.0

PS. I tried to update Gloo to latest version but it's broken...