### PR TITLE
Fix Gloo Edge flagger integration

### DIFF
--- a/pkg/apis/gloo/gloo/v1/types.go
+++ b/pkg/apis/gloo/gloo/v1/types.go
@@ -29,9 +29,9 @@ type UpstreamSpec struct {
 }
 
 type KubeUpstream struct {
-	ServiceName      string            `json:"service_name,omitempty"`
-	ServiceNamespace string            `json:"service_namespace,omitempty"`
-	ServicePort      int32             `json:"service_port,omitempty"`
+	ServiceName      string            `json:"serviceName,omitempty"`
+	ServiceNamespace string            `json:"serviceNamespace,omitempty"`
+	ServicePort      int32             `json:"servicePort,omitempty"`
 	Selector         map[string]string `json:"selector,omitempty"`
 }
 

--- a/test/gloo/install.sh
+++ b/test/gloo/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-GLOO_VER="1.6.13"
+GLOO_VER="1.8.9"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin


### PR DESCRIPTION
- Remove `ownerRef` and change json field names to camelCase rather than snake_case.