### PR TITLE
Release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.13.0
+
+**Release date:** 2021-08-25
+
+This release comes with support for [Open Service Mesh](https://openservicemesh.io).
+For more details see the [OSM Progressive Delivery tutorial](https://docs.flagger.app/tutorials/osm-progressive-delivery).
+
+Starting with this version, Flagger container images are signed with
+[sigstore/cosign](https://github.com/sigstore/cosign), for more details see the
+[Flagger cosign docs](https://github.com/fluxcd/flagger/blob/main/cosign/README.md).
+
+#### Features
+
+- Support OSM progressive traffic shifting in Flagger
+  [#955](https://github.com/fluxcd/flagger/pull/955)
+  [#977](https://github.com/fluxcd/flagger/pull/977)
+- Add support for Google Chat alerts
+  [#953](https://github.com/fluxcd/flagger/pull/953)
+
+#### Improvements
+
+- Sign Flagger container images with cosign
+  [#983](https://github.com/fluxcd/flagger/pull/983)
+- Update Gloo APIs and e2e tests to Gloo v1.8.9
+  [#982](https://github.com/fluxcd/flagger/pull/982)
+- Update e2e tests to Istio v1.11, Contour v1.18, Linkerd v2.10.2 and NGINX v0.49.0
+  [#979](https://github.com/fluxcd/flagger/pull/979)
+- Update e2e tests to Traefik to 2.4.9
+  [#960](https://github.com/fluxcd/flagger/pull/960)
+- Add support for volumes/volumeMounts in loadtester Helm chart
+  [#975](https://github.com/fluxcd/flagger/pull/975)
+- Add extra podLabels options to Flagger Helm Chart
+  [#966](https://github.com/fluxcd/flagger/pull/966)
+
+#### Fixes
+
+- Fix for the http client proxy overriding the default client
+  [#943](https://github.com/fluxcd/flagger/pull/943)
+- Drop deprecated io/ioutil
+  [#964](https://github.com/fluxcd/flagger/pull/964)
+- Remove problematic nulls from Grafana dashboard
+  [#952](https://github.com/fluxcd/flagger/pull/952)
+
 ## 1.12.1
 
 **Release date:** 2021-06-17

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.12.1
+        image: ghcr.io/fluxcd/flagger:1.13.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.12.1
-appVersion: 1.12.1
+version: 1.13.0
+appVersion: 1.13.0
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.12.1
+  tag: 1.13.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.5.0
+version: 1.6.0
 appVersion: 7.2.0
 description: Grafana dashboards for monitoring Flagger canary deployments
 icon: https://raw.githubusercontent.com/fluxcd/flagger/main/docs/logo/flagger-icon.png

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.12.1
+    newTag: 1.13.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.12.1"
+var VERSION = "1.13.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with support for [Open Service Mesh](https://openservicemesh.io). For more details see the [OSM Progressive Delivery tutorial](https://github.com/fluxcd/flagger/blob/main/docs/gitbook/tutorials/osm-progressive-delivery.md).

Starting with this version, Flagger container images are signed with [sigstore/cosign](https://github.com/sigstore/cosign), for more details see the [Flagger cosign docs](https://github.com/fluxcd/flagger/blob/main/cosign/README.md).