### PR TITLE
Fix broken loadtester chart due to extra end

### DIFF
--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: loadtester
-version: 0.19.1
+version: 0.19.2
 appVersion: 0.18.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -78,7 +78,6 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
       {{ with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Hi,

loadtester chart 0.19.1 (current main) is broken due to extra `{{ end }}` in recent commit. This PR is to fix it.

Signed-off-by: Andy Librian <andylibrian@gmail.com>

```
$ helm template charts/loadtester/
Error: parse error at (loadtester/templates/deployment.yaml:81): unexpected {{end}}

Use --debug flag to render out invalid YAML
```