### PR TITLE
Clarify that traffic routing with doesn't happen kubernetes blue/green deployment

### DIFF
--- a/docs/gitbook/usage/deployment-strategies.md
+++ b/docs/gitbook/usage/deployment-strategies.md
@@ -326,7 +326,7 @@ Blue/Green rollout steps for service mesh:
 * run conformance tests for the canary pods
 * run load tests and metric checks for the canary pods every minute
 * abort the canary release if the failure threshold is reached
-* route traffic to canary
+* route traffic to canary (This doesn't happen when using the kubernetes provider)
 * promote canary spec over primary (blue)
 * wait for primary rollout
 * route traffic to primary


### PR DESCRIPTION
This pull request updates the documentation to make it clear that routing traffic to the canary before promoting the primary doesn't happen with the Kubernetes provider.

Closes #961 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>