### PR TITLE
[docs] update promql query for istio request duration

### DIFF
--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -446,7 +446,7 @@ Istio query:
 histogram_quantile(0.99,
   sum(
     irate(
-      istio_request_duration_seconds_bucket{
+      istio_request_duration_milliseconds_bucket{
         reporter="destination",
         destination_workload=~"$workload",
         destination_workload_namespace=~"$namespace"


### PR DESCRIPTION
A minor issue I stumbled across while learning how to drive Flagger, is that the docs still use `istio_request_duration_seconds_bucket` to illustrate the query behind the `request-duration` metric. I understand that this changed with Istio 1.5 (https://github.com/fluxcd/flagger/issues/478), but it seems that in the current version of flagger, the correct metric must already be used, since I'm getting duration metrics out of Istio 1.10 :)

This change simply makes the docs clearer for those of us trying to understand exactly what `request-duration` entails!