### PR TITLE
Fixing the slack event webhook

### DIFF
--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -358,6 +358,9 @@ type CanaryWebhookPayload struct {
 
 	// Metadata (key-value pairs) for this webhook
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Text contains the payload of webhook
+	Text string `json:"text",omitempty`
 }
 
 // CrossNamespaceObjectReference contains enough information to let you locate the

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
@@ -121,5 +122,14 @@ func CallEventWebhook(r *flaggerv1.Canary, w flaggerv1.CanaryWebhook, message, e
 			payload.Metadata[key] = value
 		}
 	}
+	//Text field is the required one for slack payload
+	if strings.Contains(w.URL, "slack") {
+		var metadata string
+		for key, value := range payload.Metadata {
+			metadata += fmt.Sprintf("\n%10s%s=%s", "", key, value)
+		}
+		payload.Text = fmt.Sprintf("Name=%s\nNamespace=%s\nPhase=%s\nMetadata:%s\n", r.Name, r.Namespace, r.Status.Phase, metadata)
+	}
+
 	return callWebhook(w.URL, payload, "5s")
 }


### PR DESCRIPTION
Fixes: #1009 

slack messaging needs text field as the required one on the payload without which we are getting `no_text` response from the api - https://api.slack.com/reference/messaging/payload

```
bash-5.1$  curl -v  -d '{"Name": "flagger-hello", "Namespace": "flagger-hello", "Phase": "Initializing" }' https://hooks.slack.com/services/<<redacted>>
*   Trying 54.203.112.76...
* TCP_NODELAY set
* Connected to hooks.slack.com (54.203.112.76) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Slack Technologies, Inc.; CN=slack.com
*  start date: Apr 13 00:00:00 2021 GMT
*  expire date: Apr 18 23:59:59 2022 GMT
*  subjectAltName: host "hooks.slack.com" matched cert's "*.slack.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fa3b600f800)
> POST /services/T8D4GAD7G/B01U53LUP54/iyzXpAGJyulnjB20tQBWs7yq HTTP/2
> Host: hooks.slack.com
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 81
> Content-Type: application/x-www-form-urlencoded
>
* We are completely uploaded and fine
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 400
< date: Mon, 11 Oct 2021 23:01:40 GMT
< server: Apache
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-slack-backend: r
< access-control-allow-origin: *
< x-frame-options: SAMEORIGIN
< vary: Accept-Encoding
< referrer-policy: no-referrer
< content-type: text/html
< x-envoy-upstream-service-time: 12
< x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
< x-server: slack-www-hhvm-main-iad-f45u
< x-via: envoy-www-iad-o34u, haproxy-edge-pdx-cl52
< x-slack-shared-secret-outcome: shared-secret
< via: envoy-www-iad-o34u
<
* Connection #0 to host hooks.slack.com left intact
no_text* Closing connection 0
```

This PR is to conditionally add the text field when the event url contains "slack", thought this does not produce the output as similar to https://github.com/fluxcd/flagger/blob/main/pkg/notifier/slack.go it does provide the necessary notification which is better than not having working at all


<img width="1198" alt="Screen Shot 2021-10-11 at 4 21 33 PM" src="https://user-images.githubusercontent.com/13463361/136866483-824b92b6-d99e-4685-82ca-c9fd8df6424f.png">

