### PR TITLE
Add metadata annotations to generated apex objects

### DIFF
--- a/pkg/router/appmesh.go
+++ b/pkg/router/appmesh.go
@@ -131,10 +131,23 @@ func (ar *AppMeshRouter) reconcileVirtualNode(canary *flaggerv1.Canary, name str
 
 	// create virtual node
 	if errors.IsNotFound(err) {
+		metadata := canary.Spec.Service.Apex
+		if metadata == nil {
+			metadata = &flaggerv1.CustomMetadata{}
+		}
+		if metadata.Labels == nil {
+			metadata.Labels = make(map[string]string)
+		}
+		if metadata.Annotations == nil {
+			metadata.Annotations = make(map[string]string)
+		}
+
 		virtualnode = &appmeshv1.VirtualNode{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: canary.Namespace,
+				Name:        name,
+				Namespace:   canary.Namespace,
+				Labels:      metadata.Labels,
+				Annotations: filterMetadata(metadata.Annotations),
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(canary, schema.GroupVersionKind{
 						Group:   flaggerv1.SchemeGroupVersion.Group,

--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -145,10 +145,23 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 
 	// create virtual node
 	if errors.IsNotFound(err) {
+		metadata := canary.Spec.Service.Apex
+		if metadata == nil {
+			metadata = &flaggerv1.CustomMetadata{}
+		}
+		if metadata.Labels == nil {
+			metadata.Labels = make(map[string]string)
+		}
+		if metadata.Annotations == nil {
+			metadata.Annotations = make(map[string]string)
+		}
+
 		virtualnode = &appmeshv1.VirtualNode{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: canary.Namespace,
+				Name:        name,
+				Namespace:   canary.Namespace,
+				Labels:      metadata.Labels,
+				Annotations: filterMetadata(metadata.Annotations),
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(canary, schema.GroupVersionKind{
 						Group:   flaggerv1.SchemeGroupVersion.Group,


### PR DESCRIPTION
Some third party software relies on annotations and labels on istios VirtualServices. For instance external-dns makes use of the `external-dns.alpha.kubernetes.io/controller` annotation. Currently there is no way to set labels and annotations on the VirtualService resource.

This change takes the metadata from the `canary.Spec.Service.Apex` property to replicate exactly what is already possible for a traefik resource:
https://github.com/fluxcd/flagger/blob/c36a13ccffefbda1502bf02e8cac2f1b3ca9d027/pkg/router/traefik.go#L59-L68

Fix #854

Signed-off-by: Jonny Langefeld <jonny.langefeld@gmail.com>