### PR TITLE
Adding  fortio tool for load generation

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -5,7 +5,7 @@ RUN apk --no-cache add alpine-sdk perl curl
 RUN curl -sSLo hey "https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
-RUN curl -L https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-linux_x64-1.17.1.tgz \
+RUN curl -L https://github.com/fortio/fortio/releases/download/v1.18.0/fortio-linux_x64-1.18.0.tgz \
  | tar -C / -xvzpf -
 
 RUN HELM2_VERSION=2.16.8 && \

--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -5,6 +5,9 @@ RUN apk --no-cache add alpine-sdk perl curl
 RUN curl -sSLo hey "https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
+RUN curl -L https://github.com/fortio/fortio/releases/download/v1.17.1/fortio-linux_x64-1.17.1.tgz \
+ | tar -C / -xvzpf -
+
 RUN HELM2_VERSION=2.16.8 && \
 curl -sSL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
@@ -42,6 +45,7 @@ COPY --from=bats/bats:v1.1.0 /opt/bats/ /opt/bats/
 RUN ln -s /opt/bats/bin/bats /usr/local/bin/
 
 COPY --from=build /usr/local/bin/hey /usr/local/bin/
+COPY --from=build /usr/bin/fortio /usr/local/bin/
 COPY --from=build /tmp/wrk/wrk /usr/local/bin/
 COPY --from=build /usr/local/bin/helm /usr/local/bin/
 COPY --from=build /usr/local/bin/tiller /usr/local/bin/

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var VERSION = "0.18.1"
+var VERSION = "0.18.2"
 var (
 	logLevel          string
 	port              string


### PR DESCRIPTION
fortio is the istio benchmarking 

https://istio.io/latest/docs/ops/deployment/performance-and-scalability/#benchmarking-tools
https://github.com/fortio/fortio

This can do http as well as grpc testing which is done by two seperate tools today `hey` and  `ghz`
