### PR TITLE
Mark CanaryMetric.Threshold as omitempty

### DIFF
--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -254,7 +254,7 @@ type CanaryMetric struct {
 	Interval string `json:"interval,omitempty"`
 
 	// Deprecated: Max value accepted for this metric (replaced by ThresholdRange)
-	Threshold float64 `json:"threshold"`
+	Threshold float64 `json:"threshold,omitempty"`
 
 	// Range value accepted for this metric
 	// +optional


### PR DESCRIPTION
This is a deprecated field, so serializing it when it's unset doesn't look right.

My motivation for this change was slightly different: making this optional makes the the schema generated by [cue get go](https://cuelang.org/docs/integrations/go/#download-cue-definitions-from-go-packages) work correctly.