### PR TITLE
Prevent Flux from overriding Flagger managed objects

### DIFF
--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -150,7 +150,7 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 				Name:        name,
 				Namespace:   canary.Namespace,
 				Labels:      metadata.Labels,
-				Annotations: metadata.Annotations,
+				Annotations: filterMetadata(metadata.Annotations),
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(canary, schema.GroupVersionKind{
 						Group:   flaggerv1.SchemeGroupVersion.Group,
@@ -217,6 +217,10 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 		}
 
 		if updateService {
+			if svcClone.ObjectMeta.Annotations == nil {
+				svcClone.ObjectMeta.Annotations = make(map[string]string)
+			}
+			svcClone.ObjectMeta.Annotations = filterMetadata(svcClone.ObjectMeta.Annotations)
 			_, err = c.kubeClient.CoreV1().Services(canary.Namespace).Update(context.TODO(), svcClone, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("service %s update error: %w", name, err)

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -391,7 +391,7 @@ func TestServiceRouter_InitializeMetadata(t *testing.T) {
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(primarySvc.Annotations))
+	assert.Equal(t, 1, len(primarySvc.Annotations))
 	assert.Equal(t, "podinfo-primary", primarySvc.Labels["app"])
 }
 
@@ -423,12 +423,12 @@ func TestServiceRouter_ReconcileMetadata(t *testing.T) {
 
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(canarySvc.Annotations))
+	assert.Equal(t, 1, len(canarySvc.Annotations))
 	assert.Equal(t, "podinfo-canary", canarySvc.Labels["app"])
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(primarySvc.Annotations))
+	assert.Equal(t, 1, len(primarySvc.Annotations))
 	assert.Equal(t, "podinfo-primary", primarySvc.Labels["app"])
 
 	mocks.canary.Spec.Service.Apex = &flaggerv1.CustomMetadata{

--- a/pkg/router/traefik_test.go
+++ b/pkg/router/traefik_test.go
@@ -52,7 +52,7 @@ func TestTraefikRouter_Reconcile(t *testing.T) {
 	assert.Equal(t, uint(100), services[0].Weight)
 
 	assert.Equal(t, ts.ObjectMeta.Labels, mocks.canary.Spec.Service.Apex.Labels)
-	assert.Equal(t, ts.ObjectMeta.Annotations, mocks.canary.Spec.Service.Apex.Annotations)
+	assert.Equal(t, ts.ObjectMeta.Annotations, filterMetadata(mocks.canary.Spec.Service.Apex.Annotations))
 
 	for _, tt := range []struct {
 		name        string

--- a/pkg/router/util.go
+++ b/pkg/router/util.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 )
 
-const toolkitMarker = "toolkit.fluxcd.io"
+const (
+	toolkitMarker         = "toolkit.fluxcd.io"
+	toolkitReconcileKey   = "kustomize.toolkit.fluxcd.io/reconcile"
+	toolkitReconcileValue = "disabled"
+)
 
 func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []string) map[string]string {
 	filteredLabels := make(map[string]string)
@@ -26,10 +30,14 @@ func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []stri
 func filterMetadata(meta map[string]string) map[string]string {
 	res := make(map[string]string)
 	for k, v := range meta {
+		// remove Flux ownership
 		if strings.Contains(k, toolkitMarker) {
 			continue
 		}
 		res[k] = v
 	}
+
+	// prevent Flux from overriding Flagger managed objects
+	res[toolkitReconcileKey] = toolkitReconcileValue
 	return res
 }


### PR DESCRIPTION
Annotate the routing objects managed by Flagger (Kubernetes services, virtual services, ingresses, etc) to prevent Flux from overriding them. This change requires [Flux 0.22.0](https://github.com/fluxcd/flux2/releases/tag/v0.22.0) or newer.

This allows Flux users to add Flagger Canaries to their repos without having to delete any existing Kubernetes Services. Users that deploy apps with HelmReleases they must remove the Kubernetes Services from their charts, because Flux, when used with Helm, is not capable of ignoring changes in-cluster.