### PR TITLE
Release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.16.0
+
+**Release date:** 2021-11-22
+
+This release comes with a new API field called `primaryReadyThreshold`
+that allows setting the percentage of pods that need to be available
+to consider the primary deployment as ready.
+
+#### Features
+
+- Allow configuring threshold for primary
+  [#1048](https://github.com/fluxcd/flagger/pull/1048)
+
+#### Improvements
+
+- Append to list of ownerReferences for primary configmaps and secrets
+  [#1052](https://github.com/fluxcd/flagger/pull/1052)
+- Prevent Flux from overriding Flagger managed objects
+  [#1049](https://github.com/fluxcd/flagger/pull/1049)
+- Add warning in docs about ExternalDNS + Istio configuration
+  [#1044](https://github.com/fluxcd/flagger/pull/1044)
+
+#### Fixes
+
+- Mark `CanaryMetric.Threshold` as omitempty
+  [#1047](https://github.com/fluxcd/flagger/pull/1047)
+- Replace `ioutil` in testing of gchat
+  [#1045](https://github.com/fluxcd/flagger/pull/1045)
+
 ## 1.15.0
 
 **Release date:** 2021-10-28

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 go build \
     -ldflags "-s -w -X github.com/fluxcd/flagger/pkg/version.REVISION=${REVISON}" \
     -a -o flagger ./cmd/flagger
 
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN apk --no-cache add ca-certificates
 

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.15.0
+        image: ghcr.io/fluxcd/flagger:1.16.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.15.0
-appVersion: 1.15.0
+version: 1.16.0
+appVersion: 1.16.0
 kubeVersion: ">=1.16.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.15.0
+  tag: 1.16.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.15.0
+    newTag: 1.16.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.15.0"
+var VERSION = "1.16.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with a new API field called `primaryReadyThreshold`
that allows setting the percentage of pods that need to be available
to consider the primary deployment as ready.