### PR TITLE
Update istio-ab-testing.md

### DIFF
--- a/docs/gitbook/tutorials/istio-ab-testing.md
+++ b/docs/gitbook/tutorials/istio-ab-testing.md
@@ -135,7 +135,7 @@ spec:
         url: http://flagger-loadtester.test/
         timeout: 15s
         metadata:
-          cmd: "hey -z 1m -q 10 -c 2 -H 'Cookie: type=insider' http://podinfo.test:9898/"
+          cmd: "hey -z 1m -q 10 -c 2 -H 'Cookie: type=insider' http://podinfo-canary.test:9898/"
 ```
 
 **Note** that when using Istio 1.5 you have to replace the `request-duration` with a [metric template](https://docs.flagger.app/dev/upgrade-guide#istio-telemetry-v2).


### PR DESCRIPTION
service/podinfo.test is related to pof/podinfo-primary, so these traffic will not into pof/podinfo, result to A/B test failed.