### PR TITLE
fix: code gen sometimes fail issue

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -7,7 +7,7 @@ set -o pipefail
 SCRIPT_ROOT=$(git rev-parse --show-toplevel)
 
 # Grab code-generator version from go.sum.
-CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | head -1)
+CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | tail -1 | awk -F '/' '{print $1}')
 CODEGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
 
 echo ">> Using ${CODEGEN_PKG}"


### PR DESCRIPTION
In my self project I reference this nice script, the go.sum look like this(after run go mod tidy and
download):

```
k8s.io/apimachinery v0.22.1/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
k8s.io/apiserver v0.22.1/go.mod h1:2mcM6dzSt+XndzVQJX21Gx0/Klo7Aen7i0Ai6tIa400=
k8s.io/client-go v0.22.1 h1:jW0ZSHi8wW260FvcXHkIa0NLxFBQszTlhiAVsU5mopw=
k8s.io/client-go v0.22.1/go.mod h1:BquC5A4UOo4qVDUtoc04/+Nxp1MeHcVc1HJm1KmG8kk=
k8s.io/code-generator v0.22.1/go.mod h1:eV77Y09IopzeXOJzndrDyCI88UBok2h6WxAlBwpxa+o=
k8s.io/component-base v0.22.1 h1:SFqIXsEN3v3Kkr1bS6rstrs1wd45StJqbtgbQ4nRQdo=
```

as you can see the, sometimes the go.sum only has `version/go.mod` line,
if we run the scripts, it will fail like this:

chmod: cannot access '/home/longkai/pkg/mod/k8s.io/code-generator@v0.22.1/go.mod/generate-groups.sh': Not a directory

so this pr fix this.

Finally, the list is sort by version ast, we want to choose the newer one.