### PR TITLE
feat: allow loadtester pull secrets

### DIFF
--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       {{ with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: ghcr.io/fluxcd/flagger-loadtester
   tag: 0.19.0
   pullPolicy: IfNotPresent
+  pullSecret:
 
 podLabels: {}
 


### PR DESCRIPTION
Provide an ability to use secrets to pull images from private registries 