### PR TITLE
Publish a Software Bill of Materials (SBOM)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read # for actions/checkout to fetch code
+
 jobs:
   container:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read # for actions/checkout to fetch code
+
 jobs:
   kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -3,6 +3,9 @@ name: helm
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write # needed to push chart
+
 jobs:
   build-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-ld.yml
+++ b/.github/workflows/push-ld.yml
@@ -2,6 +2,10 @@ name: push-ld
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write # needed to write releases
+  packages: write # needed for ghcr access
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -15,13 +19,9 @@ jobs:
           echo ::set-output name=VERSION::${VERSION}
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          buildkitd-flags: "--debug"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write # needed to write releases
+  id-token: write # needed for keyless signing
+  packages: write # needed for ghcr access
+
+env:
+  IMAGE: "ghcr.io/fluxcd/${{ github.event.repository.name }}"
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -15,24 +23,28 @@ jobs:
         run: |
           VERSION=$(grep 'VERSION' pkg/version/version.go | awk '{ print $4 }' | tr -d '"')
           CHANGELOG="https://github.com/fluxcd/flagger/blob/main/CHANGELOG.md#$(echo $VERSION | tr -d '.')"
+          echo "[CHANGELOG](${CHANGELOG})" > notes.md
           echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=VERSION::${VERSION}
-          echo ::set-output name=CHANGELOG::${CHANGELOG}
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          buildkitd-flags: "--debug"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
+      - name: Generate image meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.prep.outputs.VERSION }}
       - name: Publish image
         uses: docker/build-push-action@v2
         with:
@@ -43,42 +55,31 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             REVISON=${{ github.sha }}
-          tags: |
-            ghcr.io/fluxcd/flagger:${{ steps.prep.outputs.VERSION }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Sign image
         run: |
           echo -n "${{secrets.COSIGN_PASSWORD}}" | \
           cosign sign -key ./.cosign/cosign.key -a git_sha=$GITHUB_SHA \
-          ghcr.io/fluxcd/flagger:${{ steps.prep.outputs.VERSION }}
+          ${{ env.IMAGE }}:${{ steps.prep.outputs.VERSION }}
       - name: Check images
         run: |
-          docker buildx imagetools inspect ghcr.io/fluxcd/flagger:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.prep.outputs.VERSION }}
       - name: Verifiy image signature
         run: |
           cosign verify -key ./.cosign/cosign.pub \
-          ghcr.io/fluxcd/flagger:${{ steps.prep.outputs.VERSION }}
+          ${{ env.IMAGE }}:${{ steps.prep.outputs.VERSION }}
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_url: https://flagger.app
           linting: off
-      - name: Create release
-        uses: actions/create-release@latest
+      - uses: anchore/sbom-action/download-syft@v0
+      - name: Create release and SBOM
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --release-notes=notes.md --rm-dist --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-          body: |
-            [CHANGELOG](${{ steps.prep.outputs.CHANGELOG }})

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '18 10 * * 3'
 
+permissions:
+  contents: read # for actions/checkout to fetch code
+  security-events: write # for codeQL to write security events
+
 jobs:
   fossa:
     name: FOSSA

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,14 +1,17 @@
+project_name: flagger
+
 builds:
-  - main: ./cmd/flagger
-    binary: flagger
-    ldflags: -s -w -X github.com/fluxcd/flagger/pkg/version.REVISION={{.Commit}}
-    goos:
-      - linux
-    goarch:
-      - amd64
-    env:
-      - CGO_ENABLED=0
-archives:
-  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    files:
-    - none*
+  - skip: true
+
+release:
+  prerelease: auto
+
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}_{{ .Version }}_source_code"
+
+sboms:
+  - id: source
+    artifacts: source
+    documents:
+      - "{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json"


### PR DESCRIPTION
Changes to the release workflow:
- generate [SBOM](https://www.linuxfoundation.org/blog/what-is-an-sbom/) for Flagger Go modules with [Syft](https://github.com/anchore/syft)
- publish the SBOM [SPDX](https://spdx.dev/) JSON files to GitHub releases with GoReleaser
- add permissions to GitHub Workflows