### PR TITLE
Fix for when Prometheus returns NaN

### DIFF
--- a/pkg/metrics/providers/prometheus.go
+++ b/pkg/metrics/providers/prometheus.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -148,7 +149,7 @@ func (p *PrometheusProvider) RunQuery(query string) (float64, error) {
 			value = &f
 		}
 	}
-	if value == nil {
+	if value == nil || math.IsNaN(*value) {
 		return 0, fmt.Errorf("%w", ErrNoValuesFound)
 	}
 


### PR DESCRIPTION
Flagger doesn't halt when the Prometheus return `NaN` response and continue to progress the Advancement. Fixed Prometheus provider to validate the response is NaN or not.

Signed-off-by: ashokhein <ashokhein@gmail.com>

Fix: #1098