### PR TITLE
Add field `spec.analysis.canaryReadyThreshold` for configuring canary threshold

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -829,6 +829,9 @@ spec:
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready
                       type: number
+                    canaryReadyThreshold:
+                      description: Percentage of pods that need to be available to consider canary as ready
+                      type: number
                     match:
                       description: A/B testing match conditions
                       type: array

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -829,6 +829,9 @@ spec:
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready
                       type: number
+                    canaryReadyThreshold:
+                      description: Percentage of pods that need to be available to consider canary as ready
+                      type: number
                     match:
                       description: A/B testing match conditions
                       type: array

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -343,6 +343,10 @@ Spec:
     # before starting rollout. this is optional and the default is 100
     # percentage (0-100)
     primaryReadyThreshold: 100
+    # threshold of canary pods that need to be available to consider it ready
+    # before starting rollout. this is optional and the default is 100
+    # percentage (0-100)
+    canaryReadyThreshold: 100
     # canary match conditions
     # used for A/B Testing
     match:

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -829,6 +829,9 @@ spec:
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready
                       type: number
+                    canaryReadyThreshold:
+                      description: Percentage of pods that need to be available to consider canary as ready
+                      type: number
                     match:
                       description: A/B testing match conditions
                       type: array

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -30,6 +30,7 @@ const (
 	ProgressDeadlineSeconds = 600
 	AnalysisInterval        = 60 * time.Second
 	PrimaryReadyThreshold   = 100
+	CanaryReadyThreshold    = 100
 	MetricInterval          = "1m"
 )
 
@@ -232,6 +233,9 @@ type CanaryAnalysis struct {
 
 	// Percentage of pods that need to be available to consider primary as ready
 	PrimaryReadyThreshold *int `json:"primaryReadyThreshold,omitempty"`
+
+	// Percentage of pods that need to be available to consider canary as ready
+	CanaryReadyThreshold *int `json:"canaryReadyThreshold,omitempty"`
 
 	// Alert list for this canary analysis
 	Alerts []CanaryAlert `json:"alerts,omitempty"`
@@ -450,6 +454,14 @@ func (c *Canary) GetAnalysisPrimaryReadyThreshold() int {
 		return *c.GetAnalysis().PrimaryReadyThreshold
 	}
 	return PrimaryReadyThreshold
+}
+
+// GetAnalysisCanaryReadyThreshold returns the canary canaryReadyThreshold (default 100)
+func (c *Canary) GetAnalysisCanaryReadyThreshold() int {
+	if c.GetAnalysis().CanaryReadyThreshold != nil {
+		return *c.GetAnalysis().CanaryReadyThreshold
+	}
+	return CanaryReadyThreshold
 }
 
 // GetMetricInterval returns the metric interval default value (1m)

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *CanaryAnalysis) DeepCopyInto(out *CanaryAnalysis) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.CanaryReadyThreshold != nil {
+		in, out := &in.CanaryReadyThreshold, &out.CanaryReadyThreshold
+		*out = new(int)
+		**out = **in
+	}
 	if in.Alerts != nil {
 		in, out := &in.Alerts, &out.Alerts
 		*out = make([]CanaryAlert, len(*in))

--- a/pkg/canary/daemonset_ready.go
+++ b/pkg/canary/daemonset_ready.go
@@ -52,7 +52,7 @@ func (c *DaemonSetController) IsCanaryReady(cd *flaggerv1.Canary) (bool, error) 
 		return true, fmt.Errorf("daemonset %s.%s get query error: %w", targetName, cd.Namespace, err)
 	}
 
-	retryable, err := c.isDaemonSetReady(cd, canary, 100)
+	retryable, err := c.isDaemonSetReady(cd, canary, cd.GetAnalysisCanaryReadyThreshold())
 	if err != nil {
 		return retryable, fmt.Errorf("canary damonset %s.%s not ready with retryable %v: %w",
 			targetName, cd.Namespace, retryable, err)

--- a/pkg/canary/deployment_ready.go
+++ b/pkg/canary/deployment_ready.go
@@ -59,7 +59,7 @@ func (c *DeploymentController) IsCanaryReady(cd *flaggerv1.Canary) (bool, error)
 		return true, fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
 	}
 
-	retryable, err := c.isDeploymentReady(canary, cd.GetProgressDeadlineSeconds(), 100)
+	retryable, err := c.isDeploymentReady(canary, cd.GetProgressDeadlineSeconds(), cd.GetAnalysisCanaryReadyThreshold())
 	if err != nil {
 		return retryable, fmt.Errorf(
 			"canary deployment %s.%s not ready: %w",


### PR DESCRIPTION
This pull request adds the `spec.analysis.canaryReadyThreshold` for configuring the percentage of canary workloads that must be available/ready before rollout can continue.

Fixes: #944 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>