### PR TITLE
Send warning and error alerts correctly

### DIFF
--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -98,7 +98,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 			if severity == alert.Severity {
 				shouldAlert = true
 			}
-			if severity == flaggerv1.SeverityWarn && alert.Severity == flaggerv1.SeverityError {
+			if severity == flaggerv1.SeverityError && alert.Severity == flaggerv1.SeverityWarn {
 				shouldAlert = true
 			}
 		}


### PR DESCRIPTION
This pull requests sends alerts for severity `warn` when waiting on manual confirmation AND when the analysis.
It sends alerts with severity `error` only when the analysis fails.

Closes #1072 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>