### PR TITLE
Set primary deployment replicas when autoscaler isn't used

### DIFF
--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -49,6 +49,23 @@ spec:
         timestamp: "2020-03-10T14:24:48+0000"
 ```
 
+#### How to change replicas for a deployment when not using HPA?
+
+To change replicas for a deployment when not using HPA, you have to update the canary deployment with the desired replica count
+and trigger an analysis by annotating the template. After the analysis finishes, Flagger will promote the `spec.replicas` changes to the primary deployment.
+
+Example:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  replicas: 4  #update replicas
+  template:
+    metadata:
+      annotations:
+        timestamp: "2022-02-10T14:24:48+0000" #add annotation to trigger analysis
+```
+
 #### Why is there a window of downtime during the canary initializing process when analysis is disabled?
 
 A window of downtime is the intended behavior when the analysis is disabled. This allows instant rollback and also mimics the way

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -116,6 +116,10 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 		primaryCopy.Spec.MinReadySeconds = canary.Spec.MinReadySeconds
 		primaryCopy.Spec.RevisionHistoryLimit = canary.Spec.RevisionHistoryLimit
 		primaryCopy.Spec.Strategy = canary.Spec.Strategy
+		// update replica if hpa isn't set
+		if cd.Spec.AutoscalerRef == nil {
+			primaryCopy.Spec.Replicas = canary.Spec.Replicas
+		}
 
 		// update spec with primary secrets and config maps
 		primaryCopy.Spec.Template.Spec = c.getPrimaryDeploymentTemplateSpec(canary, configRefs)


### PR DESCRIPTION
Fix: #574 

This pull request sets the replica of the primary to the replica of the canary during promotion if `spec.autoscalerRef` isn't set in the canary custom resource.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>