### PR TITLE
Remove CRDs from Helm Charts values

### DIFF
--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.crd.create -}}
-{{- range $path, $bytes := .Files.Glob "crds/*.yaml" -}}
-{{ $.Files.Get $path }}
----
-{{- end -}}
-{{- end -}}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -116,10 +116,6 @@ rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
 
-crd:
-  # crd.create: `true` if custom resource definitions should be created
-  create: false
-
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Hi all,

I am not sure if we would like to make this change, but while installing Flagger there is a weird flow.

If not setting using the `skipCRDs` in HelmRelease Flux API and passing the crd.create=true it will try to install the CRD twice.

Making this change will also follow the Helm CRD directory flow leading to possible simpler user experience.

It's probably best to ship this with a full major chart revision in the next flagger release.

I didn't bump the helm chart version because of that above and seeing that the chart version lines up with the release.

If this is agreed upon, I will run through the install docs and make the changes

Regards,
Steve Fraser