### PR TITLE
Update istio-progressive-delivery.md

### DIFF
--- a/docs/gitbook/tutorials/istio-progressive-delivery.md
+++ b/docs/gitbook/tutorials/istio-progressive-delivery.md
@@ -13,6 +13,7 @@ Install Istio with telemetry support and Prometheus:
 ```bash
 istioctl manifest install --set profile=default
 
+# Suggestion: Please change release-1.8 in below command, to your real istio version.
 kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.8/samples/addons/prometheus.yaml
 ```
 


### PR DESCRIPTION
Signed-off-by: Author Name <johnzhengaz@gmail.com>
It is easy tp raise: Halt advancement no values found for istio metric request-success-rate probably podinfo.test is not receiving traffic: running query failed: no values found
If it is inconsistence between the prometheus version and istio version.
Signed-off-by: John Zheng <john.zheng@hp.com>