### PR TITLE
Restrict source namespaces in flagger-loadtester

### DIFF
--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -59,6 +59,7 @@ Parameter | Description | Default
 `service.type` | Type of service | `ClusterIP`
 `service.port` | ClusterIP port | `80`
 `cmd.timeout` | Command execution timeout | `1h`
+`cmd.namespaceRegexp` | Restrict access to canaries in matching namespaces | ""
 `logLevel` | Log level can be debug, info, warning, error or panic | `info`
 `appmesh.enabled` | Create AWS App Mesh v1beta2 virtual node | `false`
 `appmesh.backends` | AWS App Mesh virtual services | `none`

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
             - -port=8080
             - -log-level={{ .Values.logLevel }}
             - -timeout={{ .Values.cmd.timeout }}
+            - -namespace-regexp={{ .Values.cmd.namespaceRegexp }}
           livenessProbe:
             exec:
               command:

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -17,6 +17,7 @@ podPriorityClassName: ""
 logLevel: info
 cmd:
   timeout: 1h
+  namespaceRegexp: ""
 
 nameOverride: ""
 fullnameOverride: ""

--- a/docs/gitbook/usage/webhooks.md
+++ b/docs/gitbook/usage/webhooks.md
@@ -143,7 +143,8 @@ helm repo add flagger https://flagger.app
 
 helm upgrade -i flagger-loadtester flagger/loadtester \
 --namespace=test \
---set cmd.timeout=1h
+--set cmd.timeout=1h \
+--set cmd.namespaceRegexp=''
 ```
 
 When deployed the load tester API will be available at `http://flagger-loadtester.test/`.

--- a/pkg/loadtester/authorizer.go
+++ b/pkg/loadtester/authorizer.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadtester
+
+import (
+	"regexp"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+)
+
+type Authorizer struct {
+	namespaceRegexp *regexp.Regexp
+}
+
+func NewAuthorizer(namespaceRegexp *regexp.Regexp) *Authorizer {
+	return &Authorizer{
+		namespaceRegexp: namespaceRegexp,
+	}
+}
+
+func (a *Authorizer) Authorize(payload *flaggerv1.CanaryWebhookPayload) bool {
+	return a.namespaceRegexp == nil || a.namespaceRegexp.MatchString(payload.Namespace)
+}

--- a/pkg/loadtester/server_test.go
+++ b/pkg/loadtester/server_test.go
@@ -46,7 +46,7 @@ func TestServer_HandleNewBashTaskCmdExitZero(t *testing.T) {
 			"cmd":  "echo some-output-not-to-be-returned",
 		},
 	})
-	HandleNewTask(mocks.logger, mocks.taskRunner)(resp, req)
+	HandleNewTask(mocks.logger, mocks.taskRunner, NewAuthorizer(nil))(resp, req)
 
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Empty(t, resp.Body.String())
@@ -62,7 +62,7 @@ func TestServer_HandleNewBashTaskCmdExitZeroReturnCmdOutput(t *testing.T) {
 			"returnCmdOutput": "true",
 		},
 	})
-	HandleNewTask(mocks.logger, mocks.taskRunner)(resp, req)
+	HandleNewTask(mocks.logger, mocks.taskRunner, NewAuthorizer(nil))(resp, req)
 
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, "some-output-to-be-returned\n", resp.Body.String())
@@ -78,7 +78,7 @@ func TestServer_HandleNewBashTaskCmdExitNonZero(t *testing.T) {
 		},
 	})
 
-	HandleNewTask(mocks.logger, mocks.taskRunner)(resp, req)
+	HandleNewTask(mocks.logger, mocks.taskRunner, NewAuthorizer(nil))(resp, req)
 
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
 	assert.Equal(t, "command false failed: : exit status 1", resp.Body.String())


### PR DESCRIPTION
In a multi-tenant cluster, isolating namespaces using network policies quickly becomes a requirement.
In this context, mutualizing a Flagger instance (in a dedicated namespace) is challenging, because flagger-loadtester generates cross-namespace traffic.

A simple approach is to let each tenant deploy its custom flagger-loadtester in the same namespace as its target canaries. This way, the only cross-namespace traffic is between flagger and flagger-loadtester and can be easily whitelisted by network policies.

```
                    ┌──────────────────────────────────┐
                    │                                  │
                    │                           ┌────┐ │
┌───────────┐       │                    ┌─────►│app1│ │
│           │       │                    │      └────┘ │
│ ┌───────┐ │       │  ┌─────────────────┴┐            │
│ │flagger├─┼───────┼─►│flagger-loadtester│            │
│ └───────┘ │       │  └─────────────────┬┘            │
│           │       │                    │      ┌────┐ │
└───────────┘       │                    └─────►│app2│ │
 flagger ns         │                           └────┘ │
                    │                                  │
                    └──────────────────────────────────┘
                                tenant1 ns
```

However, nothing can prevent a `Canary` from `tenant2` namespace to declare `flagger-loadtester.tenant1` as a webhook, and thus to execute arbitrary commands in `tenant1` namespace.
This creates a serious isolation issue.

This PR allows flagger-loadtester to whitelist namespaces from which canaries are allowed.
The proposed `-namespace-regex` flag looks like a simple way to address the problem, but feel free to challenge it :wink:. 