### PR TITLE
frature virtualnode output accesslog

### DIFF
--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -116,6 +116,13 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 				ar.labelSelector: podSelector,
 			},
 		},
+		Logging: &appmeshv1.Logging{
+			AccessLog: &appmeshv1.AccessLog{
+				File: &appmeshv1.FileAccessLog{
+					Path: "/dev/stdout",
+				},
+			},
+		},
 	}
 
 	backends := make([]appmeshv1.Backend, 0)


### PR DESCRIPTION
accesslog is very important for analyzing inbound and outboud traffic, 
so we want to configure it by default when creating a virtualNode