### PR TITLE
Add arm64 support for loadtester

### DIFF
--- a/.github/workflows/push-ld.yml
+++ b/.github/workflows/push-ld.yml
@@ -2,6 +2,9 @@ name: push-ld
 on:
   workflow_dispatch:
 
+env:
+  IMAGE: "ghcr.io/fluxcd/flagger-loadtester"
+
 permissions:
   contents: write # needed to write releases
   packages: write # needed for ghcr access
@@ -28,6 +31,14 @@ jobs:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
+      - name: Generate image meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.prep.outputs.VERSION }}
       - name: Publish image
         uses: docker/build-push-action@v2
         with:
@@ -35,9 +46,11 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile.loadtester
-          platforms: linux/amd64
-          tags: |
-            ghcr.io/fluxcd/flagger-loadtester:${{ steps.prep.outputs.VERSION }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            REVISION=${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Check images
         run: |
-          docker buildx imagetools inspect ghcr.io/fluxcd/flagger-loadtester:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.prep.outputs.VERSION }}

--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -1,35 +1,32 @@
-FROM alpine:3.15.0 as build
+FROM golang:1.17-alpine as builder
 
-RUN apk --no-cache add alpine-sdk perl curl
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG REVISION
 
-RUN curl -sSLo hey "https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64" && \
-chmod +x hey && mv hey /usr/local/bin/hey
+RUN apk --no-cache add alpine-sdk perl curl bash tar
 
 RUN HELM2_VERSION=2.17.0 && \
-curl -sSL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar xvz && \
-chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
-chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller
+curl -sSL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xvz && \
+chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm && \
+chmod +x linux-${TARGETARCH}/tiller && mv linux-${TARGETARCH}/tiller /usr/local/bin/tiller
 
 RUN HELM3_VERSION=3.7.2 && \
-curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | tar xvz && \
-chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3
+curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xvz && \
+chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helmv3
 
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \
-wget -qO /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+wget -qO /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
 chmod +x /usr/local/bin/grpc_health_probe
 
 RUN GHZ_VERSION=0.105.0 && \
-curl -sSL "https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz-linux-x86_64.tar.gz" | tar xz -C /tmp && \
-mv /tmp/ghz /usr/local/bin && chmod +x /usr/local/bin/ghz
+curl -sSL "https://github.com/bojand/ghz/archive/refs/tags/v${GHZ_VERSION}.tar.gz" | tar xz -C /tmp && \
+cd /tmp/ghz-${GHZ_VERSION}/cmd/ghz && GOARCH=$TARGETARCH go build . && mv ghz /usr/local/bin && \
+chmod +x /usr/local/bin/ghz
 
 RUN HELM_TILLER_VERSION=0.9.3 && \
-curl -sSL "https://github.com/rimusz/helm-tiller/archive/v${HELM_TILLER_VERSION}.tar.gz" | tar xz -C /tmp && \
-mv /tmp/helm-tiller-${HELM_TILLER_VERSION} /tmp/helm-tiller
-
-FROM golang:1.17-alpine as go
-
-ARG TARGETPLATFORM
-ARG REVISON
+curl -sSL "https://github.com/rimusz/helm-tiller/archive/refs/tags/v${HELM_TILLER_VERSION}.tar.gz" | \
+tar xz -C /tmp && mv /tmp/helm-tiller-${HELM_TILLER_VERSION} /tmp/helm-tiller
 
 WORKDIR /workspace
 
@@ -49,22 +46,23 @@ RUN CGO_ENABLED=0 go build -o loadtester ./cmd/loadtester/*
 
 FROM bash:5.0
 
+ARG TARGETPLATFORM
+
 RUN addgroup -S app && \
 adduser -S -g app app && \
-apk --no-cache add ca-certificates curl jq libgcc wrk
+apk --no-cache add ca-certificates curl jq libgcc wrk hey
 
 WORKDIR /home/app
 
 COPY --from=bats/bats:v1.1.0 /opt/bats/ /opt/bats/
 RUN ln -s /opt/bats/bin/bats /usr/local/bin/
 
-COPY --from=build /usr/local/bin/hey /usr/local/bin/
-COPY --from=build /usr/local/bin/helm /usr/local/bin/
-COPY --from=build /usr/local/bin/tiller /usr/local/bin/
-COPY --from=build /usr/local/bin/ghz /usr/local/bin/
-COPY --from=build /usr/local/bin/helmv3 /usr/local/bin/
-COPY --from=build /usr/local/bin/grpc_health_probe /usr/local/bin/
-COPY --from=build /tmp/helm-tiller /tmp/helm-tiller
+COPY --from=builder /usr/local/bin/helm /usr/local/bin/
+COPY --from=builder /usr/local/bin/tiller /usr/local/bin/
+COPY --from=builder /usr/local/bin/ghz /usr/local/bin/
+COPY --from=builder /usr/local/bin/helmv3 /usr/local/bin/
+COPY --from=builder /usr/local/bin/grpc_health_probe /usr/local/bin/
+COPY --from=builder /tmp/helm-tiller /tmp/helm-tiller
 
 ADD https://raw.githubusercontent.com/grpc/grpc-proto/master/grpc/health/v1/health.proto /tmp/ghz/health.proto
 
@@ -80,6 +78,6 @@ RUN wrk -d 1s -c 1 -t 1 https://flagger.app > /dev/null && echo $? | grep 0
 # install Helm v2 plugins
 RUN helm init --stable-repo-url=https://charts.helm.sh/stable --client-only && helm plugin install /tmp/helm-tiller
 
-COPY --from=go --chown=app:app /workspace/loadtester .
+COPY --from=builder --chown=app:app /workspace/loadtester .
 
 ENTRYPOINT ["./loadtester"]


### PR DESCRIPTION
Fixes: #1126 (partially, `arm/v7` support is difficult to add because `wrk` doesn't have an alpine package for the same)

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>