### PR TITLE
istio: Add destination port when port discovery and delegation are true

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -488,8 +488,8 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1a
 
 	// set destination port when an ingress gateway is specified
 	if canary.Spec.Service.PortDiscovery &&
-		len(canary.Spec.Service.Gateways) > 0 &&
-		canary.Spec.Service.Gateways[0] != "mesh" {
+		(len(canary.Spec.Service.Gateways) > 0 &&
+			canary.Spec.Service.Gateways[0] != "mesh" || canary.Spec.Service.Delegation) {
 		dest = istiov1alpha3.DestinationWeight{
 			Destination: istiov1alpha3.Destination{
 				Host: host,

--- a/pkg/router/istio_test.go
+++ b/pkg/router/istio_test.go
@@ -372,6 +372,9 @@ func TestIstioRouter_Delegate(t *testing.T) {
 
 		assert.Equal(t, 0, len(vs.Spec.Hosts))
 		assert.Equal(t, 0, len(vs.Spec.Gateways))
+
+		port := vs.Spec.Http[0].Route[0].Destination.Port.Number
+		assert.Equal(t, uint32(mocks.canary.Spec.Service.Port), port)
 	})
 
 	t.Run("invalid", func(t *testing.T) {


### PR DESCRIPTION
When we set `delegation: true` in an Istio canary, and we have PortDiscovery true, since having delegation results in having no gateways the destination route gets no port.
This small change makes the port to be added to the destination route when we have PortDiscovery and no gateways in the VirtualService due to having delegation.


Signed-off-by: Marco Amador <amador.marco@gmail.com>