### PR TITLE
Fix the service toggle condition in the podinfo helm chart

### DIFF
--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 6.0.0
+version: 6.0.1
 appVersion: 6.0.0
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/templates/service.yaml
+++ b/charts/podinfo/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.canary.enabled }}
+{{- if and .Values.service.enabled (not .Values.canary.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Create the service resource when it is enabled and canary is disabled

Fixes: #1002

Signed-off-by: Chen Anidam <canidam@gmail.com>