### PR TITLE
Add canary analysis result as Prometheus metrics

### DIFF
--- a/docs/gitbook/usage/monitoring.md
+++ b/docs/gitbook/usage/monitoring.md
@@ -117,4 +117,8 @@ flagger_canary_duration_seconds_bucket{name="podinfo",namespace="test",le="10"} 
 flagger_canary_duration_seconds_bucket{name="podinfo",namespace="test",le="+Inf"} 6
 flagger_canary_duration_seconds_sum{name="podinfo",namespace="test"} 17.3561329
 flagger_canary_duration_seconds_count{name="podinfo",namespace="test"} 6
+
+# Last canary metric analysis result per different metrics
+flagger_canary_metric_analysis{metric="podinfo-http-successful-rate",name="podinfo",namespace="test"} 1
+flagger_canary_metric_analysis{metric="podinfo-custom-metric",name="podinfo",namespace="test"} 0.918223108974359
 ```

--- a/pkg/controller/scheduler_metrics.go
+++ b/pkg/controller/scheduler_metrics.go
@@ -146,7 +146,7 @@ func (c *Controller) runBuiltinMetricChecks(canary *flaggerv1.Canary) bool {
 				}
 				return false
 			}
-
+			c.recorder.SetAnalysis(canary, metric.Name, val)
 			if metric.ThresholdRange != nil {
 				tr := *metric.ThresholdRange
 				if tr.Min != nil && val < *tr.Min {
@@ -177,6 +177,7 @@ func (c *Controller) runBuiltinMetricChecks(canary *flaggerv1.Canary) bool {
 				}
 				return false
 			}
+			c.recorder.SetAnalysis(canary, metric.Name, val.Seconds())
 			if metric.ThresholdRange != nil {
 				tr := *metric.ThresholdRange
 				if tr.Min != nil && val < time.Duration(*tr.Min)*time.Millisecond {
@@ -209,6 +210,7 @@ func (c *Controller) runBuiltinMetricChecks(canary *flaggerv1.Canary) bool {
 				}
 				return false
 			}
+			c.recorder.SetAnalysis(canary, metric.Name, val)
 			if metric.ThresholdRange != nil {
 				tr := *metric.ThresholdRange
 				if tr.Min != nil && val < *tr.Min {
@@ -282,6 +284,8 @@ func (c *Controller) runMetricChecks(canary *flaggerv1.Canary) bool {
 				}
 				return false
 			}
+
+			c.recorder.SetAnalysis(canary, metric.Name, val)
 
 			if metric.ThresholdRange != nil {
 				tr := *metric.ThresholdRange

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -71,8 +71,8 @@ func NewRecorder(controller string, register bool) Recorder {
 	analysis := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
 		Name:      "canary_metric_analysis",
-		Help:      "Last canary metric analysis result per different metric template",
-	}, []string{"name", "namespace", "metricTemplate"})
+		Help:      "Last canary analysis result per metric",
+	}, []string{"name", "namespace", "metric"})
 
 	if register {
 		prometheus.MustRegister(info)

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -31,6 +31,7 @@ type Recorder struct {
 	total    *prometheus.GaugeVec
 	status   *prometheus.GaugeVec
 	weight   *prometheus.GaugeVec
+	analysis *prometheus.GaugeVec
 }
 
 // NewRecorder creates a new recorder and registers the Prometheus metrics
@@ -67,12 +68,19 @@ func NewRecorder(controller string, register bool) Recorder {
 		Help:      "The virtual service destination weight current value",
 	}, []string{"workload", "namespace"})
 
+	analysis := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: controller,
+		Name:      "canary_metric_analysis",
+		Help:      "Last canary metric analysis result per different metric template",
+	}, []string{"name", "namespace", "metricTemplate"})
+
 	if register {
 		prometheus.MustRegister(info)
 		prometheus.MustRegister(duration)
 		prometheus.MustRegister(total)
 		prometheus.MustRegister(status)
 		prometheus.MustRegister(weight)
+		prometheus.MustRegister(analysis)
 	}
 
 	return Recorder{
@@ -81,6 +89,7 @@ func NewRecorder(controller string, register bool) Recorder {
 		total:    total,
 		status:   status,
 		weight:   weight,
+		analysis: analysis,
 	}
 }
 
@@ -97,6 +106,10 @@ func (cr *Recorder) SetDuration(cd *flaggerv1.Canary, duration time.Duration) {
 // SetTotal sets the total number of canaries per namespace
 func (cr *Recorder) SetTotal(namespace string, total int) {
 	cr.total.WithLabelValues(namespace).Set(float64(total))
+}
+
+func (cr *Recorder) SetAnalysis(cd *flaggerv1.Canary, metricTemplateName string, val float64) {
+	cr.analysis.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace, metricTemplateName).Set(val)
 }
 
 // SetStatus sets the last known canary analysis status


### PR DESCRIPTION
Fix of https://github.com/fluxcd/flagger/issues/1147

With this code changes,   in my demo case, I can get the following metrics:
```
# HELP flagger_canary_duration_seconds Seconds spent performing canary analysis.
# HELP flagger_canary_metric_analysis Last canary metric analysis result per different metric template
# TYPE flagger_canary_metric_analysis gauge
flagger_canary_metric_analysis{metricTemplate="flagger-helloworld-demo-error-message-analysis-existing-error-ratio",name="flagger-helloworld-demo-deployment",namespace="ying-cd-poc"} 0.918223108974359
flagger_canary_metric_analysis{metricTemplate="flagger-helloworld-demo-error-message-analysis-new-error",name="flagger-helloworld-demo-deployment",namespace="ying-cd-poc"} 1
flagger_canary_metric_analysis{metricTemplate="flagger-helloworld-demo-http-successful-rate",name="flagger-helloworld-demo-deployment",namespace="ying-cd-poc"} 100
```


Let me know if there are any testcase are required.  