### PR TITLE
Avoid setting owner refs if the service mesh/ingress is on a different cluster

### DIFF
--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -92,7 +92,7 @@ func newDaemonSetFixture(c *flaggerv1.Canary) daemonSetFixture {
 	}
 
 	// init router
-	rf := router.NewFactory(nil, kubeClient, flaggerClient, "annotationsPrefix", "", logger, flaggerClient)
+	rf := router.NewFactory(nil, kubeClient, flaggerClient, "annotationsPrefix", "", logger, flaggerClient, true)
 
 	// init observer
 	observerFactory, _ := observers.NewFactory(testMetricsServerURL)

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -120,7 +120,7 @@ func newDeploymentFixture(c *flaggerv1.Canary) fixture {
 	}
 
 	// init router
-	rf := router.NewFactory(nil, kubeClient, flaggerClient, "annotationsPrefix", "", logger, flaggerClient)
+	rf := router.NewFactory(nil, kubeClient, flaggerClient, "annotationsPrefix", "", logger, flaggerClient, true)
 
 	// init observer
 	observerFactory, _ := observers.NewFactory(testMetricsServerURL)

--- a/pkg/router/kuma.go
+++ b/pkg/router/kuma.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
@@ -85,16 +84,10 @@ func (kr *KumaRouter) Reconcile(canary *flaggerv1.Canary) error {
 			meshName = "default"
 		}
 
+		// TrafficRoute is a cluster-scoped object, hence we don't set an owner reference.
 		t := &kumav1alpha1.TrafficRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: apexName,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(canary, schema.GroupVersionKind{
-						Group:   flaggerv1.SchemeGroupVersion.Group,
-						Version: flaggerv1.SchemeGroupVersion.Version,
-						Kind:    flaggerv1.CanaryKind,
-					}),
-				},
+				Name:        apexName,
 				Annotations: filterMetadata(metadata.Annotations),
 			},
 			Spec: trSpec,

--- a/pkg/router/smi_v1alpha2.go
+++ b/pkg/router/smi_v1alpha2.go
@@ -40,6 +40,7 @@ type Smiv1alpha2Router struct {
 	smiClient     clientset.Interface
 	logger        *zap.SugaredLogger
 	targetMesh    string
+	setOwnerRefs  bool
 }
 
 // Reconcile creates or updates the SMI traffic split
@@ -72,18 +73,20 @@ func (sr *Smiv1alpha2Router) Reconcile(canary *flaggerv1.Canary) error {
 	if errors.IsNotFound(err) {
 		t := &smiv1alpha2.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      apexName,
-				Namespace: canary.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(canary, schema.GroupVersionKind{
-						Group:   flaggerv1.SchemeGroupVersion.Group,
-						Version: flaggerv1.SchemeGroupVersion.Version,
-						Kind:    flaggerv1.CanaryKind,
-					}),
-				},
+				Name:        apexName,
+				Namespace:   canary.Namespace,
 				Annotations: sr.makeAnnotations(canary.Spec.Service.Gateways),
 			},
 			Spec: tsSpec,
+		}
+		if sr.setOwnerRefs {
+			t.OwnerReferences = []metav1.OwnerReference{
+				*metav1.NewControllerRef(canary, schema.GroupVersionKind{
+					Group:   flaggerv1.SchemeGroupVersion.Group,
+					Version: flaggerv1.SchemeGroupVersion.Version,
+					Kind:    flaggerv1.CanaryKind,
+				}),
+			}
 		}
 
 		_, err := sr.smiClient.SplitV1alpha2().TrafficSplits(canary.Namespace).Create(context.TODO(), t, metav1.CreateOptions{})


### PR DESCRIPTION
Checks if the host of the cluster where Flagger is installed is different from the cluster where the ingress/service mesh is installed, and sets OwnerRefs on created resources accordingly. 

Fix: https://github.com/fluxcd/flagger/issues/694

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>