### PR TITLE
feat: Added the optional appProtocol field to Canary.Service

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -158,6 +158,9 @@ spec:
                     portName:
                       description: Container port name
                       type: string
+                    appProtocol:
+                      description: Application protocol of the port
+                      type: string
                     targetPort:
                       description: Container target port name
                       x-kubernetes-int-or-string: true

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -134,6 +134,7 @@ spec:
     name: podinfo
     port: 9898
     portName: http
+    appProtocol: http
     targetPort: 9898
     portDiscovery: true
 ```
@@ -142,6 +143,7 @@ The container port from the target workload should match the `service.port` or `
 The `service.name` is optional, defaults to `spec.targetRef.name`.
 The `service.targetPort` can be a container port number or name.
 The `service.portName` is optional (defaults to `http`), if your workload uses gRPC then set the port name to `grpc`.
+The `service.appProtocol` is optional, more details can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol).
 
 If port discovery is enabled, Flagger scans the target workload and extracts the containers ports
 excluding the port specified in the canary service and service mesh sidecar ports.

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -128,6 +128,11 @@ type CanaryService struct {
 	// +optional
 	TargetPort intstr.IntOrString `json:"targetPort,omitempty"`
 
+	// AppProtocol of the service
+	// https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+	// +optional
+	AppProtocol string `json:"appProtocol,omitempty"`
+
 	// PortDiscovery adds all container ports to the generated Kubernetes service
 	PortDiscovery bool `json:"portDiscovery"`
 

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -114,6 +114,10 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 		},
 	}
 
+	if v := canary.Spec.Service.AppProtocol; v != "" {
+		svcSpec.Ports[0].AppProtocol = &v
+	}
+
 	// set additional ports
 	for n, p := range c.ports {
 		cp := corev1.ServicePort{

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -39,6 +39,7 @@ func TestServiceRouter_Create(t *testing.T) {
 		flaggerClient: mocks.flaggerClient,
 		logger:        mocks.logger,
 	}
+	appProtocol := "http"
 
 	err := router.Initialize(mocks.canary)
 	require.NoError(t, err)
@@ -49,6 +50,7 @@ func TestServiceRouter_Create(t *testing.T) {
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
 
+	assert.Equal(t, &appProtocol, canarySvc.Spec.Ports[0].AppProtocol)
 	assert.Equal(t, "http", canarySvc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9898), canarySvc.Spec.Ports[0].Port)
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -100,6 +100,7 @@ func newTestCanary() *flaggerv1.Canary {
 			Service: flaggerv1.CanaryService{
 				Port:          9898,
 				PortDiscovery: true,
+				AppProtocol:   "http",
 				Headers: &istiov1alpha3.Headers{
 					Request: &istiov1alpha3.HeaderOperations{
 						Add: map[string]string{


### PR DESCRIPTION
Closes #1177 

Hi, and thanks in advance for your review, and apologies for the questions!

This does work locally, it propagates the appProtocol field to the services if set, and works as expected without.

Raised as a draft since I had a couple of questions:
- Should we support the appProtocol field on multiple ports, or just the first one? Are the subsequent ports irrelevant for flagger? Subsequent ports are just a map[string]int32, so would need some refactoring to support this additional field.
- Wasn't sure how best to test this and was hoping for a bit of guidance, am very new to this project. Just add it to the kubernetes_default_test file? Anywhere else? And should this have it's own test case? Or would we just be happy to ensure it works if set by adding it to the existing Finalize block?
