### PR TITLE
Rename kubeconfig section in helm values

### DIFF
--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: flagger
 version: 1.20.0
 appVersion: 1.20.0
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.19.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes
 home: https://flagger.app
@@ -18,11 +18,12 @@ keywords:
   - istio
   - appmesh
   - linkerd
+  - kuma
+  - osm
+  - smi
   - gloo
   - contour
   - nginx
   - traefik
-  - osm
-  - smi
   - gitops
   - canary

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -1,22 +1,18 @@
 # Flagger
 
-[Flagger](https://github.com/fluxcd/flagger) is an operator that automates the release process of applications on Kubernetes.
+[Flagger](https://github.com/fluxcd/flagger) is a progressive delivery tool that automates the release process
+for applications running on Kubernetes. It reduces the risk of introducing a new software version in production
+by gradually shifting traffic to the new version while measuring metrics and running conformance tests.
 
-Flagger can run automated application analysis, testing, promotion and rollback for the following deployment strategies:
-* Canary Release (progressive traffic shifting)
-* A/B Testing (HTTP headers and cookies traffic routing)
-* Blue/Green (traffic switching and mirroring)
-
-Flagger works with service mesh solutions (Istio, Linkerd, AWS App Mesh, Open Service Mesh) and with Kubernetes ingress controllers
-(NGINX, Skipper, Gloo, Contour, Traefik).
-Flagger can be configured to send alerts to various chat platforms such as Slack, Microsoft Teams, Discord and Rocket.
+Flagger implements several deployment strategies (Canary releases, A/B testing, Blue/Green mirroring)
+and integrates with various Kubernetes ingress controllers, service mesh and monitoring solutions.
 
 Flagger is a [Cloud Native Computing Foundation](https://cncf.io/) project
 and part of [Flux](https://fluxcd.io) family of GitOps tools.
 
 ## Prerequisites
 
-* Kubernetes >= 1.16
+* Kubernetes >= 1.19
 
 ## Installing the Chart
 
@@ -131,56 +127,56 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Flagger chart and their default values.
 
-| Parameter                          | Description                                                                                                                                        | Default                               |
-|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `image.repository`                 | Image repository                                                                                                                                   | `ghcr.io/fluxcd/flagger`              |
-| `image.tag`                        | Image tag                                                                                                                                          | `<VERSION>`                           |
-| `image.pullPolicy`                 | Image pull policy                                                                                                                                  | `IfNotPresent`                        |
-| `logLevel`                         | Log level                                                                                                                                          | `info`                                |
-| `metricsServer`                    | Prometheus URL, used when `prometheus.install` is `false`                                                                                          | `http://prometheus.istio-system:9090` |
-| `prometheus.install`               | If `true`, installs Prometheus configured to scrape all pods in the custer                                                                         | `false`                               |
-| `prometheus.retention`             | Prometheus data retention                                                                                                                          | `2h`                                  |
-| `selectorLabels`                   | List of labels that Flagger uses to create pod selectors                                                                                           | `app,name,app.kubernetes.io/name`     |
-| `configTracking.enabled`           | If `true`, flagger will track changes in Secrets and ConfigMaps referenced in the target deployment                                                | `true`                                |
-| `eventWebhook`                     | If set, Flagger will publish events to the given webhook                                                                                           | None                                  |
-| `slack.url`                        | Slack incoming webhook                                                                                                                             | None                                  |
-| `slack.proxyUrl`                   | Slack proxy url                                                                                                                                    | None                                  |
-| `slack.channel`                    | Slack channel                                                                                                                                      | None                                  |
-| `slack.user`                       | Slack username                                                                                                                                     | `flagger`                             |
-| `msteams.url`                      | Microsoft Teams incoming webhook                                                                                                                   | None                                  |
-| `msteams.proxyUrl`                 | Microsoft Teams proxy url                                                                                                                          | None                                  |
-| `clusterName`                      | When specified, Flagger will add the cluster name to alerts                                                                                        | `""`                                  |
-| `podMonitor.enabled`               | If `true`, create a PodMonitor for [monitoring the metrics](https://docs.flagger.app/usage/monitoring#metrics)                                     | `false`                               |
-| `podMonitor.namespace`             | Namespace where the PodMonitor is created                                                                                                          | the same namespace                    |
-| `podMonitor.interval`              | Interval at which metrics should be scraped                                                                                                        | `15s`                                 |
-| `podMonitor.podMonitor`            | Additional labels to add to the PodMonitor                                                                                                         | `{}`                                  |
-| `leaderElection.enabled`           | If `true`, Flagger will run in HA mode                                                                                                             | `false`                               |
-| `leaderElection.replicaCount`      | Number of replicas                                                                                                                                 | `1`                                   |
-| `serviceAccount.create`            | If `true`, Flagger will create service account                                                                                                     | `true`                                |
-| `serviceAccount.name`              | The name of the service account to create or use. If not set and `serviceAccount.create` is `true`, a name is generated using the Flagger fullname | `""`                                  |
-| `serviceAccount.annotations`       | Annotations for service account                                                                                                                    | `{}`                                  |
-| `ingressAnnotationsPrefix`         | Annotations prefix for ingresses                                                                                                                   | `custom.ingress.kubernetes.io`        |
-| `includeLabelPrefix`               | List of prefixes of labels that are copied when creating primary deployments or daemonsets. Use * to include all                                   | `""`                                  |
-| `rbac.create`                      | If `true`, create and use RBAC resources                                                                                                           | `true`                                |
-| `rbac.pspEnabled`                  | If `true`, create and use a restricted pod security policy                                                                                         | `false`                               |
-| `crd.create`                       | If `true`, create Flagger's CRDs (should be enabled for Helm v2 only)                                                                              | `false`                               |
-| `resources.requests/cpu`           | Pod CPU request                                                                                                                                    | `10m`                                 |
-| `resources.requests/memory`        | Pod memory request                                                                                                                                 | `32Mi`                                |
-| `resources.limits/cpu`             | Pod CPU limit                                                                                                                                      | `1000m`                               |
-| `resources.limits/memory`          | Pod memory limit                                                                                                                                   | `512Mi`                               |
-| `affinity`                         | Node/pod affinities                                                                                                                                | None                                  |
-| `nodeSelector`                     | Node labels for pod assignment                                                                                                                     | `{}`                                  |
-| `threadiness`                      | Number of controller workers                                                                                                                       | `2`                                   |
-| `tolerations`                      | List of node taints to tolerate                                                                                                                    | `[]`                                  |
-| `istio.kubeconfig.secretName`      | The name of the Kubernetes secret containing the Istio shared control plane kubeconfig                                                             | None                                  |
-| `istio.kubeconfig.key`             | The name of Kubernetes secret data key that contains the Istio control plane kubeconfig                                                            | `kubeconfig`                          |
-| `ingressAnnotationsPrefix`         | Annotations prefix for NGINX ingresses                                                                                                             | None                                  |
-| `ingressClass`                     | Ingress class used for annotating HTTPProxy objects, e.g. `contour`                                                                                | None                                  |
-| `podPriorityClassName`             | PriorityClass name for pod priority configuration                                                                                                  | ""                                    |
-| `podDisruptionBudget.enabled`      | A PodDisruptionBudget will be created if `true`                                                                                                    | `false`                               |
-| `podDisruptionBudget.minAvailable` | The minimal number of available replicas that will be set in the PodDisruptionBudget                                                               | `1`                                   |
-| `podDisruptionBudget.minAvailable` | The minimal number of available replicas that will be set in the PodDisruptionBudget                                                               | `1`                                   |
-| `noCrossNamespaceRefs`             | If `true`, cross namespace references to custom resources will be disabled.                                                                        | `false`                               |
+| Parameter                            | Description                                                                                                                                        | Default                               |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `image.repository`                   | Image repository                                                                                                                                   | `ghcr.io/fluxcd/flagger`              |
+| `image.tag`                          | Image tag                                                                                                                                          | `<VERSION>`                           |
+| `image.pullPolicy`                   | Image pull policy                                                                                                                                  | `IfNotPresent`                        |
+| `logLevel`                           | Log level                                                                                                                                          | `info`                                |
+| `metricsServer`                      | Prometheus URL, used when `prometheus.install` is `false`                                                                                          | `http://prometheus.istio-system:9090` |
+| `prometheus.install`                 | If `true`, installs Prometheus configured to scrape all pods in the custer                                                                         | `false`                               |
+| `prometheus.retention`               | Prometheus data retention                                                                                                                          | `2h`                                  |
+| `selectorLabels`                     | List of labels that Flagger uses to create pod selectors                                                                                           | `app,name,app.kubernetes.io/name`     |
+| `configTracking.enabled`             | If `true`, flagger will track changes in Secrets and ConfigMaps referenced in the target deployment                                                | `true`                                |
+| `eventWebhook`                       | If set, Flagger will publish events to the given webhook                                                                                           | None                                  |
+| `slack.url`                          | Slack incoming webhook                                                                                                                             | None                                  |
+| `slack.proxyUrl`                     | Slack proxy url                                                                                                                                    | None                                  |
+| `slack.channel`                      | Slack channel                                                                                                                                      | None                                  |
+| `slack.user`                         | Slack username                                                                                                                                     | `flagger`                             |
+| `msteams.url`                        | Microsoft Teams incoming webhook                                                                                                                   | None                                  |
+| `msteams.proxyUrl`                   | Microsoft Teams proxy url                                                                                                                          | None                                  |
+| `clusterName`                        | When specified, Flagger will add the cluster name to alerts                                                                                        | `""`                                  |
+| `podMonitor.enabled`                 | If `true`, create a PodMonitor for [monitoring the metrics](https://docs.flagger.app/usage/monitoring#metrics)                                     | `false`                               |
+| `podMonitor.namespace`               | Namespace where the PodMonitor is created                                                                                                          | the same namespace                    |
+| `podMonitor.interval`                | Interval at which metrics should be scraped                                                                                                        | `15s`                                 |
+| `podMonitor.podMonitor`              | Additional labels to add to the PodMonitor                                                                                                         | `{}`                                  |
+| `leaderElection.enabled`             | If `true`, Flagger will run in HA mode                                                                                                             | `false`                               |
+| `leaderElection.replicaCount`        | Number of replicas                                                                                                                                 | `1`                                   |
+| `serviceAccount.create`              | If `true`, Flagger will create service account                                                                                                     | `true`                                |
+| `serviceAccount.name`                | The name of the service account to create or use. If not set and `serviceAccount.create` is `true`, a name is generated using the Flagger fullname | `""`                                  |
+| `serviceAccount.annotations`         | Annotations for service account                                                                                                                    | `{}`                                  |
+| `ingressAnnotationsPrefix`           | Annotations prefix for ingresses                                                                                                                   | `custom.ingress.kubernetes.io`        |
+| `includeLabelPrefix`                 | List of prefixes of labels that are copied when creating primary deployments or daemonsets. Use * to include all                                   | `""`                                  |
+| `rbac.create`                        | If `true`, create and use RBAC resources                                                                                                           | `true`                                |
+| `rbac.pspEnabled`                    | If `true`, create and use a restricted pod security policy                                                                                         | `false`                               |
+| `crd.create`                         | If `true`, create Flagger's CRDs (should be enabled for Helm v2 only)                                                                              | `false`                               |
+| `resources.requests/cpu`             | Pod CPU request                                                                                                                                    | `10m`                                 |
+| `resources.requests/memory`          | Pod memory request                                                                                                                                 | `32Mi`                                |
+| `resources.limits/cpu`               | Pod CPU limit                                                                                                                                      | `1000m`                               |
+| `resources.limits/memory`            | Pod memory limit                                                                                                                                   | `512Mi`                               |
+| `affinity`                           | Node/pod affinities                                                                                                                                | None                                  |
+| `nodeSelector`                       | Node labels for pod assignment                                                                                                                     | `{}`                                  |
+| `threadiness`                        | Number of controller workers                                                                                                                       | `2`                                   |
+| `tolerations`                        | List of node taints to tolerate                                                                                                                    | `[]`                                  |
+| `controlplane.kubeconfig.secretName` | The name of the Kubernetes secret containing the service mesh control plane kubeconfig                                                             | None                                  |
+| `controlplane.kubeconfig.key`        | The name of Kubernetes secret data key that contains the service mesh control plane kubeconfig                                                     | `kubeconfig`                          |
+| `ingressAnnotationsPrefix`           | Annotations prefix for NGINX ingresses                                                                                                             | None                                  |
+| `ingressClass`                       | Ingress class used for annotating HTTPProxy objects, e.g. `contour`                                                                                | None                                  |
+| `podPriorityClassName`               | PriorityClass name for pod priority configuration                                                                                                  | ""                                    |
+| `podDisruptionBudget.enabled`        | A PodDisruptionBudget will be created if `true`                                                                                                    | `false`                               |
+| `podDisruptionBudget.minAvailable`   | The minimal number of available replicas that will be set in the PodDisruptionBudget                                                               | `1`                                   |
+| `podDisruptionBudget.minAvailable`   | The minimal number of available replicas that will be set in the PodDisruptionBudget                                                               | `1`                                   |
+| `noCrossNamespaceRefs`               | If `true`, cross namespace references to custom resources will be disabled                                                                         | `false`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -48,10 +48,10 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       volumes:
-        {{- if .Values.istio.kubeconfig.secretName }}
+        {{- if .Values.controlplane.kubeconfig.secretName }}
         - name: kubeconfig
           secret:
-            secretName: "{{ .Values.istio.kubeconfig.secretName }}"
+            secretName: "{{ .Values.controlplane.kubeconfig.secretName }}"
         {{- end }}
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
@@ -63,9 +63,9 @@ spec:
 {{ toYaml .Values.securityContext.context | indent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.istio.kubeconfig.secretName }}
+            {{- if .Values.controlplane.kubeconfig.secretName }}
             - name: kubeconfig
-              mountPath: "/tmp/istio-host"
+              mountPath: "/tmp/controlplane"
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -132,8 +132,8 @@ spec:
           {{- if .Values.kubeconfigBurst }}
           - -kubeconfig-burst={{ .Values.kubeconfigBurst }}
           {{- end }}
-          {{- if .Values.istio.kubeconfig.secretName }}
-          - -kubeconfig-service-mesh=/tmp/istio-host/{{ .Values.istio.kubeconfig.key }}
+          {{- if .Values.controlplane.kubeconfig.secretName }}
+          - -kubeconfig-service-mesh=/tmp/controlplane/{{ .Values.controlplane.kubeconfig.key }}
           {{- end }}
           {{- if .Values.threadiness }}
           - -threadiness={{ .Values.threadiness }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -151,13 +151,12 @@ prometheus:
 kubeconfigQPS: ""
 kubeconfigBurst: ""
 
-#  Istio multi-cluster service mesh (shared control plane single-network)
-# https://istio.io/docs/setup/install/multicluster/shared-vpn/
-istio:
+#  Multi-cluster service mesh (shared control plane single-network)
+controlplane:
   kubeconfig:
-    # istio.kubeconfig.secretName: The name of the secret containing the Istio control plane kubeconfig
+    # controlplane.kubeconfig.secretName: The name of the secret containing the mesh control plane kubeconfig
     secretName: ""
-    # istio.kubeconfig.key: The name of secret data key that contains the Istio control plane kubeconfig
+    # controlplane.kubeconfig.key: The name of secret data key that contains the mesh control plane kubeconfig
     key: "kubeconfig"
 
 podDisruptionBudget:

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -43,8 +43,8 @@ helm upgrade -i flagger flagger/flagger \
 --set crd.create=false \
 --set meshProvider=istio \
 --set metricsServer=http://istio-cluster-prometheus:9090 \
---set istio.kubeconfig.secretName=istio-kubeconfig \
---set istio.kubeconfig.key=kubeconfig
+--set controlplane.kubeconfig.secretName=istio-kubeconfig \
+--set controlplane.kubeconfig.key=kubeconfig
 ```
 
 Note that the Istio kubeconfig must be stored in a Kubernetes secret with a data key named `kubeconfig`.


### PR DESCRIPTION
Changes:
- rename `istio.kubeconfig` to `controlplane.kubeconfig` ref: #1170 
- bump the minimum required version to Kubernetes 1.19
- update the chart readme to match the main readme