### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.21.0
+
+**Release date:** 2022-05-06
+
+This release comes with an option to disable cross-namespace references to Kubernetes
+custom resources such as `AlertProivders` and `MetricProviders`. When running Flagger
+on multi-tenant environments it is advised to set the `-no-cross-namespace-refs=true` flag.
+
+In addition, this version enables Flagger to target Istio and Kuma multi-cluster setups.
+When installing Flagger with Helm, the service mesh control plane kubeconfig secret
+can be specified using `--set controlplane.kubeconfig.secretName`.
+
+#### Improvements
+
+- Add flag to disable cross namespace refs to custom resources
+  [#1181](https://github.com/fluxcd/flagger/pull/1181)
+- Rename kubeconfig section in helm values
+  [#1188](https://github.com/fluxcd/flagger/pull/1188)
+- Update Flagger overview diagram
+  [#1187](https://github.com/fluxcd/flagger/pull/1187)
+
+#### Fixes
+
+- Avoid setting owner refs if the service mesh/ingress is on a different cluster
+  [#1183](https://github.com/fluxcd/flagger/pull/1183)
+
 ## 1.20.0
 
 **Release date:** 2022-04-15

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.20.0
+        image: ghcr.io/fluxcd/flagger:1.21.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.20.0
-appVersion: 1.20.0
+version: 1.21.0
+appVersion: 1.21.0
 kubeVersion: ">=1.19.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.20.0
+  tag: 1.21.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.20.0
+    newTag: 1.21.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.20.0"
+var VERSION = "1.21.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with an option to disable cross-namespace references to Kubernetes
custom resources such as `AlertProivders` and `MetricProviders`. When running Flagger
on multi-tenant environments it is advised to set the `-no-cross-namespace-refs=true` flag.

In addition, this version enables Flagger to target Istio and Kuma multi-cluster setups.
When installing Flagger with Helm, the service mesh control plane kubeconfig secret
can be specified using `--set controlplane.kubeconfig.secretName`.