### PR TITLE
Introduce `ScalerReconciler` and refactor HPA reconciliation

### DIFF
--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -48,7 +48,6 @@ type DeploymentController struct {
 // Initialize creates the primary deployment, hpa,
 // scales to zero the canary deployment and returns the pod selector label and container ports
 func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
-	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
 	if err := c.createPrimaryDeployment(cd, c.includeLabelPrefix); err != nil {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
 	}
@@ -67,16 +66,6 @@ func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 		}
 	}
 
-	if cd.Spec.AutoscalerRef != nil {
-		if cd.Spec.AutoscalerRef.Kind == "HorizontalPodAutoscaler" {
-			if err := c.reconcilePrimaryHpa(cd, true); err != nil {
-				return fmt.Errorf(
-					"initial reconcilePrimaryHpa for %s.%s failed: %w", primaryName, cd.Namespace, err)
-			}
-		} else {
-			return fmt.Errorf("cd.Spec.AutoscalerRef.Kind is invalid: %s", cd.Spec.AutoscalerRef.Kind)
-		}
-	}
 	return nil
 }
 
@@ -155,17 +144,6 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 			primaryName, cd.Namespace, err)
 	}
 
-	// update HPA
-	if cd.Spec.AutoscalerRef != nil {
-		if cd.Spec.AutoscalerRef.Kind == "HorizontalPodAutoscaler" {
-			if err := c.reconcilePrimaryHpa(cd, false); err != nil {
-				return fmt.Errorf(
-					"reconcilePrimaryHpa for %s.%s failed: %w", primaryName, cd.Namespace, err)
-			}
-		} else {
-			return fmt.Errorf("cd.Spec.AutoscalerRef.Kind is invalid: %s", cd.Spec.AutoscalerRef.Kind)
-		}
-	}
 	return nil
 }
 

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
-	hpav2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,7 +90,6 @@ func newCustomizableFixture(dc deploymentConfigs) (deploymentControllerFixture, 
 	// init kube clientset and register mock objects
 	kubeClient := fake.NewSimpleClientset(
 		newDeploymentControllerTest(dc),
-		newDeploymentControllerTestHPA(),
 		newDeploymentControllerTestConfigMap(),
 		newDeploymentControllerTestConfigMapEnv(),
 		newDeploymentControllerTestConfigMapVol(),
@@ -999,34 +997,4 @@ func newDeploymentControllerTestV2() *appsv1.Deployment {
 	}
 
 	return d
-}
-
-func newDeploymentControllerTestHPA() *hpav2.HorizontalPodAutoscaler {
-	h := &hpav2.HorizontalPodAutoscaler{
-		TypeMeta: metav1.TypeMeta{APIVersion: hpav2.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "podinfo",
-		},
-		Spec: hpav2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: hpav2.CrossVersionObjectReference{
-				Name:       "podinfo",
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-			},
-			Metrics: []hpav2.MetricSpec{
-				{
-					Type: "Resource",
-					Resource: &hpav2.ResourceMetricSource{
-						Name: "cpu",
-						Target: hpav2.MetricTarget{
-							AverageUtilization: int32p(99),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return h
 }

--- a/pkg/canary/factory.go
+++ b/pkg/canary/factory.go
@@ -83,3 +83,19 @@ func (factory *Factory) Controller(kind string) Controller {
 		return deploymentCtrl
 	}
 }
+
+func (factory *Factory) ScalerReconciler(kind string) ScalerReconciler {
+	hpaReconciler := &HPAReconciler{
+		logger:             factory.logger,
+		kubeClient:         factory.kubeClient,
+		flaggerClient:      factory.flaggerClient,
+		includeLabelPrefix: factory.includeLabelPrefix,
+	}
+
+	switch kind {
+	case "HorizontalPodAutoscaler":
+		return hpaReconciler
+	default:
+		return nil
+	}
+}

--- a/pkg/canary/hpa_reconciler.go
+++ b/pkg/canary/hpa_reconciler.go
@@ -1,0 +1,258 @@
+package canary
+
+import (
+	"context"
+	"fmt"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	hpav2 "k8s.io/api/autoscaling/v2"
+	hpav2beta2 "k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// HPAReconciler is a ScalerReconciler that reconciles HPAs.
+type HPAReconciler struct {
+	kubeClient         kubernetes.Interface
+	flaggerClient      clientset.Interface
+	logger             *zap.SugaredLogger
+	includeLabelPrefix []string
+}
+
+func (hr *HPAReconciler) ReconcilePrimaryScaler(cd *flaggerv1.Canary, init bool) error {
+	if cd.Spec.AutoscalerRef != nil {
+		if err := hr.reconcilePrimaryHpa(cd, init); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (hr *HPAReconciler) reconcilePrimaryHpa(cd *flaggerv1.Canary, init bool) error {
+	var betaHpa *hpav2beta2.HorizontalPodAutoscaler
+	hpa, err := hr.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), cd.Spec.AutoscalerRef.Name, metav1.GetOptions{})
+	if err != nil {
+		hr.logger.Debugf("v2 HorizontalPodAutoscaler %s.%s get query error: %w; falling back to v2beta2",
+			cd.Namespace, cd.Spec.AutoscalerRef.Name, err)
+		var betaErr error
+		betaHpa, betaErr = hr.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), cd.Spec.AutoscalerRef.Name, metav1.GetOptions{})
+		if betaErr != nil {
+			return fmt.Errorf("HorizontalPodAutoscaler %s.%s get query error for both v2beta2: %s and v2: %s",
+				cd.Spec.AutoscalerRef.Name, cd.Namespace, betaErr, err)
+		}
+	}
+
+	if hpa != nil {
+		if err = hr.reconcilePrimaryHpaV2(cd, hpa, init); err != nil {
+			return err
+		}
+	} else if betaHpa != nil {
+		if err = hr.reconcilePrimaryHpaV2Beta2(cd, betaHpa, init); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (hr *HPAReconciler) reconcilePrimaryHpaV2(cd *flaggerv1.Canary, hpa *hpav2.HorizontalPodAutoscaler, init bool) error {
+	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
+
+	hpaSpec := hpav2.HorizontalPodAutoscalerSpec{
+		ScaleTargetRef: hpav2.CrossVersionObjectReference{
+			Name:       primaryName,
+			Kind:       hpa.Spec.ScaleTargetRef.Kind,
+			APIVersion: hpa.Spec.ScaleTargetRef.APIVersion,
+		},
+		MinReplicas: hpa.Spec.MinReplicas,
+		MaxReplicas: hpa.Spec.MaxReplicas,
+		Metrics:     hpa.Spec.Metrics,
+		Behavior:    hpa.Spec.Behavior,
+	}
+
+	primaryHpaName := fmt.Sprintf("%s-primary", cd.Spec.AutoscalerRef.Name)
+	primaryHpa, err := hr.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), primaryHpaName, metav1.GetOptions{})
+
+	// create HPA
+	if errors.IsNotFound(err) {
+		primaryHpa = &hpav2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      primaryHpaName,
+				Namespace: cd.Namespace,
+				Labels:    filterMetadata(hpa.Labels),
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
+						Group:   flaggerv1.SchemeGroupVersion.Group,
+						Version: flaggerv1.SchemeGroupVersion.Version,
+						Kind:    flaggerv1.CanaryKind,
+					}),
+				},
+			},
+			Spec: hpaSpec,
+		}
+
+		_, err = hr.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(cd.Namespace).Create(context.TODO(), primaryHpa, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating HorizontalPodAutoscaler %s.%s failed: %w",
+				primaryHpa.Name, primaryHpa.Namespace, err)
+		}
+		hr.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Infof(
+			"HorizontalPodAutoscaler %s.%s created", primaryHpa.GetName(), cd.Namespace)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("HorizontalPodAutoscaler %s.%s get query failed: %w",
+			primaryHpa.Name, primaryHpa.Namespace, err)
+	}
+
+	// update HPA
+	if !init && primaryHpa != nil {
+		diffMetrics := cmp.Diff(hpaSpec.Metrics, primaryHpa.Spec.Metrics)
+		diffBehavior := cmp.Diff(hpaSpec.Behavior, primaryHpa.Spec.Behavior)
+		diffLabels := cmp.Diff(hpa.ObjectMeta.Labels, primaryHpa.ObjectMeta.Labels)
+		diffAnnotations := cmp.Diff(hpa.ObjectMeta.Annotations, primaryHpa.ObjectMeta.Annotations)
+		if diffMetrics != "" || diffBehavior != "" || diffLabels != "" || diffAnnotations != "" || int32Default(hpaSpec.MinReplicas) != int32Default(primaryHpa.Spec.MinReplicas) || hpaSpec.MaxReplicas != primaryHpa.Spec.MaxReplicas {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				primaryHpa, err := hr.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), primaryHpaName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				hpaClone := primaryHpa.DeepCopy()
+				hpaClone.Spec.MaxReplicas = hpaSpec.MaxReplicas
+				hpaClone.Spec.MinReplicas = hpaSpec.MinReplicas
+				hpaClone.Spec.Metrics = hpaSpec.Metrics
+				hpaClone.Spec.Behavior = hpaSpec.Behavior
+
+				// update hpa annotations
+				hpaClone.ObjectMeta.Annotations = make(map[string]string)
+				filteredAnnotations := includeLabelsByPrefix(hpa.ObjectMeta.Annotations, hr.includeLabelPrefix)
+				for k, v := range filteredAnnotations {
+					hpaClone.ObjectMeta.Annotations[k] = v
+				}
+				// update hpa labels
+				hpaClone.ObjectMeta.Labels = make(map[string]string)
+				filteredLabels := includeLabelsByPrefix(hpa.ObjectMeta.Labels, hr.includeLabelPrefix)
+				for k, v := range filteredLabels {
+					hpaClone.ObjectMeta.Labels[k] = v
+				}
+
+				_, err = hr.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(cd.Namespace).Update(context.TODO(), hpaClone, metav1.UpdateOptions{})
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("updating HorizontalPodAutoscaler %s.%s failed: %w",
+					primaryHpa.Name, primaryHpa.Namespace, err)
+			}
+			hr.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+				Infof("HorizontalPodAutoscaler %s.%s updated", primaryHpa.GetName(), cd.Namespace)
+		}
+	}
+	return nil
+}
+
+func (hr *HPAReconciler) reconcilePrimaryHpaV2Beta2(cd *flaggerv1.Canary, hpa *hpav2beta2.HorizontalPodAutoscaler, init bool) error {
+	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
+
+	hpaSpec := hpav2beta2.HorizontalPodAutoscalerSpec{
+		ScaleTargetRef: hpav2beta2.CrossVersionObjectReference{
+			Name:       primaryName,
+			Kind:       hpa.Spec.ScaleTargetRef.Kind,
+			APIVersion: hpa.Spec.ScaleTargetRef.APIVersion,
+		},
+		MinReplicas: hpa.Spec.MinReplicas,
+		MaxReplicas: hpa.Spec.MaxReplicas,
+		Metrics:     hpa.Spec.Metrics,
+		Behavior:    hpa.Spec.Behavior,
+	}
+
+	primaryHpaName := fmt.Sprintf("%s-primary", cd.Spec.AutoscalerRef.Name)
+	primaryHpa, err := hr.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), primaryHpaName, metav1.GetOptions{})
+
+	// create HPA
+	if errors.IsNotFound(err) {
+		primaryHpa = &hpav2beta2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      primaryHpaName,
+				Namespace: cd.Namespace,
+				Labels:    filterMetadata(hpa.Labels),
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
+						Group:   flaggerv1.SchemeGroupVersion.Group,
+						Version: flaggerv1.SchemeGroupVersion.Version,
+						Kind:    flaggerv1.CanaryKind,
+					}),
+				},
+			},
+			Spec: hpaSpec,
+		}
+
+		_, err = hr.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(cd.Namespace).Create(context.TODO(), primaryHpa, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating HorizontalPodAutoscaler %s.%s failed: %w",
+				primaryHpa.Name, primaryHpa.Namespace, err)
+		}
+		hr.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Infof(
+			"HorizontalPodAutoscaler %s.%s created", primaryHpa.GetName(), cd.Namespace)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("HorizontalPodAutoscaler %s.%s get query failed: %w",
+			primaryHpa.Name, primaryHpa.Namespace, err)
+	}
+
+	// update HPA
+	if !init && primaryHpa != nil {
+		diffMetrics := cmp.Diff(hpaSpec.Metrics, primaryHpa.Spec.Metrics)
+		diffBehavior := cmp.Diff(hpaSpec.Behavior, primaryHpa.Spec.Behavior)
+		diffLabels := cmp.Diff(hpa.ObjectMeta.Labels, primaryHpa.ObjectMeta.Labels)
+		diffAnnotations := cmp.Diff(hpa.ObjectMeta.Annotations, primaryHpa.ObjectMeta.Annotations)
+		if diffMetrics != "" || diffBehavior != "" || diffLabels != "" || diffAnnotations != "" || int32Default(hpaSpec.MinReplicas) != int32Default(primaryHpa.Spec.MinReplicas) || hpaSpec.MaxReplicas != primaryHpa.Spec.MaxReplicas {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				primaryHpa, err := hr.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(cd.Namespace).Get(context.TODO(), primaryHpaName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				hpaClone := primaryHpa.DeepCopy()
+				hpaClone.Spec.MaxReplicas = hpaSpec.MaxReplicas
+				hpaClone.Spec.MinReplicas = hpaSpec.MinReplicas
+				hpaClone.Spec.Metrics = hpaSpec.Metrics
+				hpaClone.Spec.Behavior = hpaSpec.Behavior
+
+				// update hpa annotations
+				hpaClone.ObjectMeta.Annotations = make(map[string]string)
+				filteredAnnotations := includeLabelsByPrefix(hpa.ObjectMeta.Annotations, hr.includeLabelPrefix)
+				for k, v := range filteredAnnotations {
+					hpaClone.ObjectMeta.Annotations[k] = v
+				}
+				// update hpa labels
+				hpaClone.ObjectMeta.Labels = make(map[string]string)
+				filteredLabels := includeLabelsByPrefix(hpa.ObjectMeta.Labels, hr.includeLabelPrefix)
+				for k, v := range filteredLabels {
+					hpaClone.ObjectMeta.Labels[k] = v
+				}
+
+				_, err = hr.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(cd.Namespace).Update(context.TODO(), hpaClone, metav1.UpdateOptions{})
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("updating HorizontalPodAutoscaler %s.%s failed: %w",
+					primaryHpa.Name, primaryHpa.Namespace, err)
+			}
+			hr.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+				Infof("HorizontalPodAutoscaler %s.%s updated", primaryHpa.GetName(), cd.Namespace)
+		}
+	}
+	return nil
+}
+
+func (hr *HPAReconciler) PauseTargetScaler(cd *flaggerv1.Canary) error {
+	return nil
+}
+
+func (hr *HPAReconciler) ResumeTargetScaler(cd *flaggerv1.Canary) error {
+	return nil
+}

--- a/pkg/canary/hpa_reconciler_test.go
+++ b/pkg/canary/hpa_reconciler_test.go
@@ -63,6 +63,7 @@ func Test_reconcilePrimaryHpaV2(t *testing.T) {
 	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 99)
 
 	hpa.Spec.Metrics[0].Resource.Target = hpav2.MetricTarget{AverageUtilization: int32p(50)}
+	hpa.Spec.MaxReplicas = 10
 	_, err = mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -72,6 +73,7 @@ func Test_reconcilePrimaryHpaV2(t *testing.T) {
 	primaryHPA, err = mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 50)
+	assert.Equal(t, int(primaryHPA.Spec.MaxReplicas), 10)
 }
 
 func Test_reconcilePrimaryHpaV2Beta2(t *testing.T) {
@@ -94,6 +96,7 @@ func Test_reconcilePrimaryHpaV2Beta2(t *testing.T) {
 	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 99)
 
 	hpa.Spec.Metrics[0].Resource.Target = hpav2beta2.MetricTarget{AverageUtilization: int32p(50)}
+	hpa.Spec.MaxReplicas = 10
 	_, err = mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -103,4 +106,5 @@ func Test_reconcilePrimaryHpaV2Beta2(t *testing.T) {
 	primaryHPA, err = mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 50)
+	assert.Equal(t, int(primaryHPA.Spec.MaxReplicas), 10)
 }

--- a/pkg/canary/hpa_reconciler_test.go
+++ b/pkg/canary/hpa_reconciler_test.go
@@ -1,0 +1,106 @@
+package canary
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	hpav2 "k8s.io/api/autoscaling/v2"
+	hpav2beta2 "k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_reconcilePrimaryHpa(t *testing.T) {
+	mocks := newScalerReconcilerFixture(scalerConfig{
+		targetName: "podinfo",
+		scaler:     "HorizontalPodAutoscaler",
+		// avoid creating a v2 HPA.
+		excludeObjs: []string{"HPAV2"},
+	})
+	hpaReconciler := mocks.scalerReconciler.(*HPAReconciler)
+
+	err := hpaReconciler.reconcilePrimaryHpa(mocks.canary, true)
+	require.NoError(t, err)
+
+	// assert that we fallback to v2beta2, when HPAv2 fails.
+	_, err = mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+
+	hpa, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, hpa)
+
+	mocks = newScalerReconcilerFixture(scalerConfig{
+		targetName: "podinfo",
+		scaler:     "HorizontalPodAutoscaler",
+		// avoid creating _any_ HPAs.
+		excludeObjs: []string{"HPAV2", "HPAV2Beta2"},
+	})
+	hpaReconciler = mocks.scalerReconciler.(*HPAReconciler)
+	// assert that we return an error if no HPAs are found.
+	err = hpaReconciler.reconcilePrimaryHpa(mocks.canary, true)
+	require.Error(t, err)
+}
+
+func Test_reconcilePrimaryHpaV2(t *testing.T) {
+	mocks := newScalerReconcilerFixture(scalerConfig{
+		targetName: "podinfo",
+		scaler:     "HorizontalPodAutoscaler",
+	})
+	hpaReconciler := mocks.scalerReconciler.(*HPAReconciler)
+
+	hpa, err := mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	err = hpaReconciler.reconcilePrimaryHpaV2(mocks.canary, hpa, true)
+	require.NoError(t, err)
+
+	primaryHPA, err := mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, primaryHPA.Spec.ScaleTargetRef.Name, "podinfo-primary")
+	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 99)
+
+	hpa.Spec.Metrics[0].Resource.Target = hpav2.MetricTarget{AverageUtilization: int32p(50)}
+	_, err = mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = hpaReconciler.reconcilePrimaryHpaV2(mocks.canary, hpa, false)
+	require.NoError(t, err)
+
+	primaryHPA, err = mocks.kubeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 50)
+}
+
+func Test_reconcilePrimaryHpaV2Beta2(t *testing.T) {
+	mocks := newScalerReconcilerFixture(scalerConfig{
+		targetName: "podinfo",
+		scaler:     "HorizontalPodAutoscaler",
+	})
+
+	hpaReconciler := mocks.scalerReconciler.(*HPAReconciler)
+
+	hpa, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	err = hpaReconciler.reconcilePrimaryHpaV2Beta2(mocks.canary, hpa, true)
+	require.NoError(t, err)
+
+	primaryHPA, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, primaryHPA.Spec.ScaleTargetRef.Name, "podinfo-primary")
+	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 99)
+
+	hpa.Spec.Metrics[0].Resource.Target = hpav2beta2.MetricTarget{AverageUtilization: int32p(50)}
+	_, err = mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = hpaReconciler.reconcilePrimaryHpaV2Beta2(mocks.canary, hpa, false)
+	require.NoError(t, err)
+
+	primaryHPA, err = mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int(*primaryHPA.Spec.Metrics[0].Resource.Target.AverageUtilization), 50)
+}

--- a/pkg/canary/scaler_reconciler.go
+++ b/pkg/canary/scaler_reconciler.go
@@ -1,0 +1,13 @@
+package canary
+
+import (
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+)
+
+// ScalerReconciler represents a reconciler that can reconcile resources
+// that can scale other resources.
+type ScalerReconciler interface {
+	ReconcilePrimaryScaler(cd *flaggerv1.Canary, init bool) error
+	PauseTargetScaler(cd *flaggerv1.Canary) error
+	ResumeTargetScaler(cd *flaggerv1.Canary) error
+}

--- a/pkg/canary/scaler_reconciler_fixture_test.go
+++ b/pkg/canary/scaler_reconciler_fixture_test.go
@@ -1,0 +1,136 @@
+package canary
+
+import (
+	"go.uber.org/zap"
+	hpav2 "k8s.io/api/autoscaling/v2"
+	hpav2beta2 "k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
+	fakeFlagger "github.com/fluxcd/flagger/pkg/client/clientset/versioned/fake"
+	"github.com/fluxcd/flagger/pkg/logger"
+)
+
+type scalerReconcilerFixture struct {
+	canary           *flaggerv1.Canary
+	kubeClient       kubernetes.Interface
+	flaggerClient    clientset.Interface
+	scalerReconciler ScalerReconciler
+	logger           *zap.SugaredLogger
+}
+
+type scalerConfig struct {
+	targetName  string
+	excludeObjs []string
+	scaler      string
+}
+
+func newScalerReconcilerFixture(cfg scalerConfig) scalerReconcilerFixture {
+	canary := newDeploymentControllerTestCanary(canaryConfigs{targetName: cfg.targetName})
+	flaggerClient := fakeFlagger.NewSimpleClientset(canary)
+
+	kubeClient := fake.NewSimpleClientset(
+		newScalerReconcilerTestHPAV2(),
+		newScalerReconcilerTestHPAV2Beta2(),
+	)
+	for _, obj := range cfg.excludeObjs {
+		if obj == "HPAV2" {
+			kubeClient.Tracker().Delete(schema.GroupVersionResource{
+				Group:    "autoscaling",
+				Version:  "v2",
+				Resource: "horizontalpodautoscalers",
+			}, "default", "podinfo")
+		}
+		if obj == "HPAV2Beta2" {
+			kubeClient.Tracker().Delete(schema.GroupVersionResource{
+				Group:    "autoscaling",
+				Version:  "v2beta2",
+				Resource: "horizontalpodautoscalers",
+			}, "default", "podinfo")
+		}
+	}
+
+	logger, _ := logger.NewLogger("debug")
+	var hpaReconciler HPAReconciler
+
+	if cfg.scaler == "HorizontalPodAutoscaler" {
+		hpaReconciler = HPAReconciler{
+			kubeClient:         kubeClient,
+			flaggerClient:      flaggerClient,
+			logger:             logger,
+			includeLabelPrefix: []string{"app.kubernetes.io"},
+		}
+	}
+
+	return scalerReconcilerFixture{
+		canary:           canary,
+		kubeClient:       kubeClient,
+		flaggerClient:    flaggerClient,
+		scalerReconciler: &hpaReconciler,
+		logger:           logger,
+	}
+}
+
+func newScalerReconcilerTestHPAV2Beta2() *hpav2beta2.HorizontalPodAutoscaler {
+	h := &hpav2beta2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{APIVersion: hpav2beta2.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo",
+		},
+		Spec: hpav2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: hpav2beta2.CrossVersionObjectReference{
+				Name:       "podinfo",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			Metrics: []hpav2beta2.MetricSpec{
+				{
+					Type: "Resource",
+					Resource: &hpav2beta2.ResourceMetricSource{
+						Name: "cpu",
+						Target: hpav2beta2.MetricTarget{
+							AverageUtilization: int32p(99),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return h
+}
+
+func newScalerReconcilerTestHPAV2() *hpav2.HorizontalPodAutoscaler {
+	h := &hpav2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{APIVersion: hpav2.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo",
+		},
+		Spec: hpav2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: hpav2.CrossVersionObjectReference{
+				Name:       "podinfo",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			Metrics: []hpav2.MetricSpec{
+				{
+					Type: "Resource",
+					Resource: &hpav2.ResourceMetricSource{
+						Name: "cpu",
+						Target: hpav2.MetricTarget{
+							AverageUtilization: int32p(99),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return h
+}

--- a/test/kubernetes/run.sh
+++ b/test/kubernetes/run.sh
@@ -10,3 +10,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 "$REPO_ROOT"/test/workloads/init.sh
 "$DIR"/test-deployment.sh
 "$DIR"/test-daemonset.sh
+
+kubectl -n test delete deploy podinfo
+kubectl -n test delete svc podinfo-svc
+kubectl apply -f ${REPO_ROOT}/test/workloads/deployment.yaml -n test
+"$DIR"/test-hpa.sh

--- a/test/kubernetes/test-hpa.sh
+++ b/test/kubernetes/test-hpa.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+cat <<EOF | kubectl apply -f -
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: podinfo
+  namespace: test
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 99
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: podinfo-svc
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: podinfo
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+---
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo
+  namespace: test
+spec:
+  provider: kubernetes
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  autoscalerRef:
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    name: podinfo
+  progressDeadlineSeconds: 60
+  service:
+    port: 80
+    targetPort: 9898
+    name: podinfo-svc
+    portDiscovery: true
+  analysis:
+    interval: 15s
+    threshold: 10
+    iterations: 5
+    metrics:
+      - name: request-success-rate
+        interval: 1m
+        thresholdRange:
+          min: 99
+      - name: request-duration
+        interval: 30s
+        thresholdRange:
+          max: 500
+    webhooks:
+      - name: "gate"
+        type: confirm-rollout
+        url: http://flagger-loadtester.test/gate/approve
+      - name: acceptance-test
+        type: pre-rollout
+        url: http://flagger-loadtester.test/
+        timeout: 10s
+        metadata:
+          type: bash
+          cmd: "curl -sd 'test' http://podinfo-svc-canary/token | grep token"
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 10m -q 10 -c 2 http://podinfo-svc-canary.test/"
+EOF
+
+echo '>>> Waiting for primary to be ready'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n test get canary/podinfo | grep 'Initialized' && ok=true || ok=false
+    sleep 5
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+echo '✔ Canary initialization test passed'
+
+echo '>>> Waiting for primary HPA to be created'
+retries=10
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n test get hpa podinfo-primary && ok=true || ok=false
+    sleep 2
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        echo '⨯ Primary HPA not found'
+        exit 1
+    fi
+done
+
+echo '✔ Primary HPA successfully reconciled'
+
+# update the target hpa resource utilization
+kubectl -n test patch hpa podinfo --type json --patch='[ { "op": "replace", "path": "/spec/metrics/0/resource/target/averageUtilization", "value": 50 } ]'
+
+echo '>>> Triggering canary deployment'
+kubectl -n test set image deployment/podinfo podinfod=ghcr.io/stefanprodan/podinfo:6.0.1
+
+echo '>>> Waiting for canary promotion'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n test describe deployment/podinfo-primary | grep '6.0.1' && ok=true || ok=false
+    sleep 10
+    kubectl -n flagger-system logs deployment/flagger --tail 1
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n test describe deployment/podinfo
+        kubectl -n test describe deployment/podinfo-primary
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+echo '✔ Canary promotion test passed'
+
+util=$(kubectl -n test get hpa podinfo -ojsonpath='{.spec.metrics[0].resource.target.averageUtilization}' | xargs)
+if [[ ${util} -eq 50 ]]; then
+    echo '✔ Primary HPA successfully reconciled'
+else
+    echo "⨯ Unexpected primary HPA resource target average utilization value: ${util}, expected: 50"
+    exit 1
+fi


### PR DESCRIPTION
This PR introduces a new interface `ScalerReconciler`,  which provides methods to reconcile a scaler like HPAs, or KEDA ScaledObjects. For now, the existing HPA reconciliation logic has been refactored to implement this, is moved out of the deployment controller and is used directly in the main reconciliation loop.