### PR TITLE
typo: boostrap -> bootstrap

### DIFF
--- a/docs/gitbook/tutorials/appmesh-progressive-delivery.md
+++ b/docs/gitbook/tutorials/appmesh-progressive-delivery.md
@@ -171,7 +171,7 @@ virtualservice.appmesh.k8s.aws/podinfo
 virtualservice.appmesh.k8s.aws/podinfo-canary
 ```
 
-After the boostrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test`
+After the bootstrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test`
 will be routed to the primary pods.
 During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
 

--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -157,7 +157,7 @@ service/podinfo-primary
 httpproxy.projectcontour.io/podinfo
 ```
 
-After the boostrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
+After the bootstrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
 
 ## Expose the app outside the cluster
 

--- a/docs/gitbook/tutorials/kuma-progressive-delivery.md
+++ b/docs/gitbook/tutorials/kuma-progressive-delivery.md
@@ -133,7 +133,7 @@ service/podinfo-primary
 trafficroutes.kuma.io/podinfo
 ```
 
-After the boostrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
+After the bootstrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
 
 ## Automated canary promotion
 

--- a/docs/gitbook/tutorials/linkerd-progressive-delivery.md
+++ b/docs/gitbook/tutorials/linkerd-progressive-delivery.md
@@ -140,7 +140,7 @@ service/podinfo-primary
 trafficsplits.split.smi-spec.io/podinfo
 ```
 
-After the boostrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
+After the bootstrap, the podinfo deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods. During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
 
 ## Automated canary promotion
 

--- a/docs/gitbook/tutorials/osm-progressive-delivery.md
+++ b/docs/gitbook/tutorials/osm-progressive-delivery.md
@@ -166,7 +166,7 @@ service/podinfo-primary
 trafficsplits.split.smi-spec.io/podinfo
 ```
 
-After the boostrap, the `podinfo` deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods.
+After the bootstrap, the `podinfo` deployment will be scaled to zero and the traffic to `podinfo.test` will be routed to the primary pods.
 During the canary analysis, the `podinfo-canary.test` address can be used to target directly the canary pods.
 
 ## Automated Canary Promotion


### PR DESCRIPTION
https://github.com/fluxcd/website/commit/dd700d8ff39da0835d527a1aabb7ca89c53db74d

I should have fixed this in flagger instead.

Signed-off-by: Daniel Holbach <daniel@weave.works>