### PR TITLE
include Contour retryOn in the sample canary

### DIFF
--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -90,7 +90,7 @@ spec:
     retries:
       attempts: 3
       perTryTimeout: 5s
-      # supported values for retryOn - https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on
+      # supported values for retryOn - https://projectcontour.io/docs/main/config/api/#projectcontour.io/v1.RetryOn
       retryOn: "5xx"
   # define the canary analysis timing and KPIs
   analysis:

--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -90,6 +90,8 @@ spec:
     retries:
       attempts: 3
       perTryTimeout: 5s
+      # supported values for retryOn - https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on
+      retryOn: "5xx"
   # define the canary analysis timing and KPIs
   analysis:
     # schedule interval (default 60s)


### PR DESCRIPTION
without this change the HTTPProxy - podinfo.test was not getting created due to this warning:

```
test               4m11s       Warning   Synced                         canary/podinfo                               HTTPProxy podinfo.test create error: HTTPProxy.projectcontour.io "podinfo" is invalid: spec.routes.retryPolicy.retryOn: Unsupported value: "": supported values: "5xx", "gateway-error", "reset", "connect-failure", "retriable-4xx", "refused-stream", "retriable-status-codes", "retriable-headers", "cancelled", "deadline-exceeded", "internal", "resource-exhausted", "unavailable"

```

Signed-off-by: Mae Anne Large <Mpluya@users.noreply.github.com>