### PR TITLE
Reintroducing empty check for metric template references.

### DIFF
--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -108,7 +108,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 
 		// determine alert provider namespace
 		providerNamespace := canary.GetNamespace()
-		if alert.ProviderRef.Namespace != canary.Namespace {
+		if alert.ProviderRef.Namespace != canary.Namespace && alert.ProviderRef.Namespace != "" {
 			providerNamespace = alert.ProviderRef.Namespace
 		}
 

--- a/pkg/controller/scheduler_metrics.go
+++ b/pkg/controller/scheduler_metrics.go
@@ -54,7 +54,7 @@ func (c *Controller) checkMetricProviderAvailability(canary *flaggerv1.Canary) e
 
 		if metric.TemplateRef != nil {
 			namespace := canary.Namespace
-			if metric.TemplateRef.Namespace != canary.Namespace {
+			if metric.TemplateRef.Namespace != canary.Namespace && metric.TemplateRef.Namespace != "" {
 				namespace = metric.TemplateRef.Namespace
 			}
 
@@ -238,7 +238,7 @@ func (c *Controller) runMetricChecks(canary *flaggerv1.Canary) bool {
 	for _, metric := range canary.GetAnalysis().Metrics {
 		if metric.TemplateRef != nil {
 			namespace := canary.Namespace
-			if metric.TemplateRef.Namespace != canary.Namespace {
+			if metric.TemplateRef.Namespace != canary.Namespace && metric.TemplateRef.Namespace != "" {
 				namespace = metric.TemplateRef.Namespace
 			}
 

--- a/pkg/controller/scheduler_metrics_test.go
+++ b/pkg/controller/scheduler_metrics_test.go
@@ -69,7 +69,6 @@ func TestController_checkMetricProviderAvailability(t *testing.T) {
 	})
 
 	t.Run("intraNamespaceTemplateRef", func(t *testing.T) {
-
 		ctrl := newDeploymentFixture(nil).ctrl
 		analysis := &flaggerv1.CanaryAnalysis{Metrics: []flaggerv1.CanaryMetric{{
 			Name: "", TemplateRef: &flaggerv1.CrossNamespaceObjectReference{

--- a/pkg/controller/scheduler_metrics_test.go
+++ b/pkg/controller/scheduler_metrics_test.go
@@ -25,6 +25,7 @@ import (
 
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	"github.com/fluxcd/flagger/pkg/metrics/observers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestController_checkMetricProviderAvailability(t *testing.T) {
@@ -63,6 +64,21 @@ func TestController_checkMetricProviderAvailability(t *testing.T) {
 		canary.Spec.Analysis.Metrics[0].TemplateRef = &flaggerv1.CrossNamespaceObjectReference{
 			Name:      "envoy",
 			Namespace: "default",
+		}
+		require.NoError(t, ctrl.checkMetricProviderAvailability(canary))
+	})
+
+	t.Run("intraNamespaceTemplateRef", func(t *testing.T) {
+
+		ctrl := newDeploymentFixture(nil).ctrl
+		analysis := &flaggerv1.CanaryAnalysis{Metrics: []flaggerv1.CanaryMetric{{
+			Name: "", TemplateRef: &flaggerv1.CrossNamespaceObjectReference{
+				Name: "envoy",
+			},
+		}}}
+		canary := &flaggerv1.Canary{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+			Spec:       flaggerv1.CanarySpec{Analysis: analysis},
 		}
 		require.NoError(t, ctrl.checkMetricProviderAvailability(canary))
 	})


### PR DESCRIPTION
Reverting removal of empty string check in commit 7df1beef85e4de3f4761bd20e7665d87d840e734 to support the namespace being optional. Adding test for future validation.