### PR TITLE
Implement different traffic distribution policies based on the header

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -54,6 +54,10 @@ spec:
         - name: LastTransitionTime
           type: string
           jsonPath: .status.lastTransitionTime
+        - name: TrafficType
+          type: string
+          jsonPath: .spec.analysis.trafficType
+          priority: 1
       schema:
         openAPIV3Schema:
           description: Canary is the Schema for the Canary API.
@@ -867,6 +871,9 @@ spec:
                       type: boolean
                     mirrorWeight:
                       description: Weight of traffic to be mirrored
+                      type: number
+                    trafficType:
+                      description: Type of forwarded traffic split  by header "1" is native "2" is request by service
                       type: number
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -54,6 +54,10 @@ spec:
         - name: LastTransitionTime
           type: string
           jsonPath: .status.lastTransitionTime
+        - name: TrafficType
+          type: string
+          jsonPath: .spec.analysis.trafficType
+          priority: 1
       schema:
         openAPIV3Schema:
           description: Canary is the Schema for the Canary API.
@@ -867,6 +871,9 @@ spec:
                       type: boolean
                     mirrorWeight:
                       description: Weight of traffic to be mirrored
+                      type: number
+                    trafficType:
+                      description: Type of forwarded traffic split  by header "1" is native "2" is request by service
                       type: number
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -54,6 +54,10 @@ spec:
         - name: LastTransitionTime
           type: string
           jsonPath: .status.lastTransitionTime
+        - name: TrafficType
+          type: string
+          jsonPath: .spec.analysis.trafficType
+          priority: 1
       schema:
         openAPIV3Schema:
           description: Canary is the Schema for the Canary API.
@@ -867,6 +871,9 @@ spec:
                       type: boolean
                     mirrorWeight:
                       description: Weight of traffic to be mirrored
+                      type: number
+                    trafficType:
+                      description: Type of forwarded traffic split  by header "1" is native "2" is request by service
                       type: number
                     primaryReadyThreshold:
                       description: Percentage of pods that need to be available to consider primary as ready

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -239,6 +239,10 @@ type CanaryAnalysis struct {
 	// +optional
 	StepWeightPromotion int `json:"stepWeightPromotion,omitempty"`
 
+	// Incremental traffic split type by header for analysis phase
+	// +optional
+	TrafficType int `json:"trafficType,omitempty"`
+
 	// Max number of failed checks before the canary is terminated
 	Threshold int `json:"threshold"`
 

--- a/pkg/apis/gatewayapi/v1alpha2/httproute_types.go
+++ b/pkg/apis/gatewayapi/v1alpha2/httproute_types.go
@@ -284,9 +284,9 @@ const (
 //
 // Invalid values include:
 //
-// * ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-//   headers are not currently supported by this type.
-// * "/invalid" - "/" is an invalid character
+//   - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+//     headers are not currently supported by this type.
+//   - "/invalid" - "/" is an invalid character
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=256
@@ -411,11 +411,13 @@ const (
 //
 // ```
 // match:
-//   path:
-//     value: "/foo"
-//   headers:
-//   - name: "version"
-//     value "v1"
+//
+//	path:
+//	  value: "/foo"
+//	headers:
+//	- name: "version"
+//	  value "v1"
+//
 // ```
 type HTTPRouteMatch struct {
 	// Path specifies a HTTP request path matcher. If this field is not
@@ -855,9 +857,9 @@ type HTTPRouteStatus struct {
 // Hostname is the fully qualified domain name of a network host. This matches
 // the RFC 1123 definition of a hostname with 2 notable exceptions:
 //
-// 1. IPs are not allowed.
-// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//    label must appear by itself as the first label.
+//  1. IPs are not allowed.
+//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+//     label must appear by itself as the first label.
 //
 // Hostname can be "precise" which is a domain name without the terminating
 // dot of a network host (e.g. "foo.example.com") or "wildcard", which is a

--- a/pkg/apis/istio/v1alpha3/destination_rule.go
+++ b/pkg/apis/istio/v1alpha3/destination_rule.go
@@ -21,17 +21,18 @@ type DestinationRule struct {
 // balancing pool. For example, a simple load balancing policy for the
 // ratings service would look as follows:
 //
-//
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-ratings
-// spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy:
-//     loadBalancer:
-//       simple: LEAST_CONN
 //
+//	name: bookinfo-ratings
+//
+// spec:
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy:
+//	  loadBalancer:
+//	    simple: LEAST_CONN
 //
 // Version specific policies can be specified by defining a named
 // subset and overriding the settings specified at the service level. The
@@ -39,24 +40,25 @@ type DestinationRule struct {
 // going to a subset named testversion that is composed of endpoints (e.g.,
 // pods) with labels (version:v3).
 //
-//
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-ratings
-// spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy:
-//     loadBalancer:
-//       simple: LEAST_CONN
-//   subsets:
-//   - name: testversion
-//     labels:
-//       version: v3
-//     trafficPolicy:
-//       loadBalancer:
-//         simple: ROUND_ROBIN
 //
+//	name: bookinfo-ratings
+//
+// spec:
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy:
+//	  loadBalancer:
+//	    simple: LEAST_CONN
+//	subsets:
+//	- name: testversion
+//	  labels:
+//	    version: v3
+//	  trafficPolicy:
+//	    loadBalancer:
+//	      simple: ROUND_ROBIN
 //
 // **Note:** Policies specified for subsets will not take effect until
 // a route rule explicitly sends traffic to this subset.
@@ -66,24 +68,25 @@ type DestinationRule struct {
 // traffic to port 80, while uses a round robin load balancing setting for
 // traffic to the port 9080.
 //
-//
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-ratings-port
-// spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy: # Apply to all ports
-//     portLevelSettings:
-//     - port:
-//         number: 80
-//       loadBalancer:
-//         simple: LEAST_CONN
-//     - port:
-//         number: 9080
-//       loadBalancer:
-//         simple: ROUND_ROBIN
 //
+//	name: bookinfo-ratings-port
+//
+// spec:
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy: # Apply to all ports
+//	  portLevelSettings:
+//	  - port:
+//	      number: 80
+//	    loadBalancer:
+//	      simple: LEAST_CONN
+//	  - port:
+//	      number: 9080
+//	    loadBalancer:
+//	      simple: ROUND_ROBIN
 type DestinationRuleSpec struct {
 	// REQUIRED. The name of a service from the service registry. Service
 	// names are looked up from the platform's service registry (e.g.,
@@ -172,19 +175,22 @@ type PortTrafficPolicy struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-ratings
+//
+//	name: bookinfo-ratings
+//
 // spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy:
-//     loadBalancer:
-//       simple: LEAST_CONN
-//   subsets:
-//   - name: testversion
-//     labels:
-//       version: v3
-//     trafficPolicy:
-//       loadBalancer:
-//         simple: ROUND_ROBIN
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy:
+//	  loadBalancer:
+//	    simple: LEAST_CONN
+//	subsets:
+//	- name: testversion
+//	  labels:
+//	    version: v3
+//	  trafficPolicy:
+//	    loadBalancer:
+//	      simple: ROUND_ROBIN
 //
 // **Note:** Policies specified for subsets will not take effect until
 // a route rule explicitly sends traffic to this subset.
@@ -215,29 +221,32 @@ type Subset struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-ratings
+//
+//	name: bookinfo-ratings
+//
 // spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy:
-//     loadBalancer:
-//       simple: ROUND_ROBIN
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy:
+//	  loadBalancer:
+//	    simple: ROUND_ROBIN
 //
 // The following example sets up sticky sessions for the ratings service
 // hashing-based load balancer for the same ratings service using the
 // the User cookie as the hash key.
 //
-//  apiVersion: networking.istio.io/v1alpha3
-//  kind: DestinationRule
-//  metadata:
-//    name: bookinfo-ratings
-//  spec:
-//    host: ratings.prod.svc.cluster.local
-//    trafficPolicy:
-//      loadBalancer:
-//        consistentHash:
-//          httpCookie:
-//            name: user
-//            ttl: 0s
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: DestinationRule
+//	metadata:
+//	  name: bookinfo-ratings
+//	spec:
+//	  host: ratings.prod.svc.cluster.local
+//	  trafficPolicy:
+//	    loadBalancer:
+//	      consistentHash:
+//	        httpCookie:
+//	          name: user
+//	          ttl: 0s
 type LoadBalancerSettings struct {
 	// It is required to specify exactly one of the fields:
 	// Simple or ConsistentHash
@@ -265,15 +274,17 @@ type LoadBalancerSettings struct {
 // A similar setting is specified for traffic originating in "us-west/zone2/*".
 //
 // ```yaml
-//   distribute:
-//     - from: us-west/zone1/*
-//       to:
-//         "us-west/zone1/*": 80
-//         "us-west/zone2/*": 20
-//     - from: us-west/zone2/*
-//       to:
-//         "us-west/zone1/*": 20
-//         "us-west/zone2/*": 80
+//
+//	distribute:
+//	  - from: us-west/zone1/*
+//	    to:
+//	      "us-west/zone1/*": 80
+//	      "us-west/zone2/*": 20
+//	  - from: us-west/zone2/*
+//	    to:
+//	      "us-west/zone1/*": 20
+//	      "us-west/zone2/*": 80
+//
 // ```
 //
 // If the goal of the operator is not to distribute load across zones and
@@ -288,11 +299,13 @@ type LoadBalancerSettings struct {
 // and similarly us-west should failover to us-east.
 //
 // ```yaml
-//  failover:
-//    - from: us-east
-//      to: eu-west
-//    - from: us-west
-//      to: us-east
+//
+//	failover:
+//	  - from: us-east
+//	    to: eu-west
+//	  - from: us-west
+//	    to: us-east
+//
 // ```
 // Locality load balancing settings.
 type LocalityLbSetting struct {
@@ -461,14 +474,17 @@ type HTTPCookie struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: bookinfo-redis
+//
+//	name: bookinfo-redis
+//
 // spec:
-//   host: myredissrv.prod.svc.cluster.local
-//   trafficPolicy:
-//     connectionPool:
-//       tcp:
-//         maxConnections: 100
-//         connectTimeout: 30ms
+//
+//	host: myredissrv.prod.svc.cluster.local
+//	trafficPolicy:
+//	  connectionPool:
+//	    tcp:
+//	      maxConnections: 100
+//	      connectTimeout: 30ms
 type ConnectionPoolSettings struct {
 
 	// Settings common to both HTTP and TCP upstream connections.
@@ -535,20 +551,23 @@ type HTTPSettings struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: reviews-cb-policy
+//
+//	name: reviews-cb-policy
+//
 // spec:
-//   host: reviews.prod.svc.cluster.local
-//   trafficPolicy:
-//     connectionPool:
-//       tcp:
-//         maxConnections: 100
-//       http:
-//         http2MaxRequests: 1000
-//         maxRequestsPerConnection: 10
-//     outlierDetection:
-//       consecutiveErrors: 7
-//       interval: 5m
-//       baseEjectionTime: 15m
+//
+//	host: reviews.prod.svc.cluster.local
+//	trafficPolicy:
+//	  connectionPool:
+//	    tcp:
+//	      maxConnections: 100
+//	    http:
+//	      http2MaxRequests: 1000
+//	      maxRequestsPerConnection: 10
+//	  outlierDetection:
+//	    consecutiveErrors: 7
+//	    interval: 5m
+//	    baseEjectionTime: 15m
 type OutlierDetection struct {
 	// Number of errors before a host is ejected from the connection
 	// pool. Defaults to 5. When the upstream host is accessed over HTTP, a
@@ -621,15 +640,18 @@ type OutlierDetection struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: db-mtls
+//
+//	name: db-mtls
+//
 // spec:
-//   host: mydbserver.prod.svc.cluster.local
-//   trafficPolicy:
-//     tls:
-//       mode: MUTUAL
-//       clientCertificate: /etc/certs/myclientcert.pem
-//       privateKey: /etc/certs/client_private_key.pem
-//       caCertificates: /etc/certs/rootcacerts.pem
+//
+//	host: mydbserver.prod.svc.cluster.local
+//	trafficPolicy:
+//	  tls:
+//	    mode: MUTUAL
+//	    clientCertificate: /etc/certs/myclientcert.pem
+//	    privateKey: /etc/certs/client_private_key.pem
+//	    caCertificates: /etc/certs/rootcacerts.pem
 //
 // The following rule configures a client to use TLS when talking to a
 // foreign service whose domain matches *.foo.com.
@@ -637,12 +659,15 @@ type OutlierDetection struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: tls-foo
+//
+//	name: tls-foo
+//
 // spec:
-//   host: "*.foo.com"
-//   trafficPolicy:
-//     tls:
-//       mode: SIMPLE
+//
+//	host: "*.foo.com"
+//	trafficPolicy:
+//	  tls:
+//	    mode: SIMPLE
 //
 // The following rule configures a client to use Istio mutual TLS when talking
 // to rating services.
@@ -650,12 +675,15 @@ type OutlierDetection struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: ratings-istio-mtls
+//
+//	name: ratings-istio-mtls
+//
 // spec:
-//   host: ratings.prod.svc.cluster.local
-//   trafficPolicy:
-//     tls:
-//       mode: ISTIO_MUTUAL
+//
+//	host: ratings.prod.svc.cluster.local
+//	trafficPolicy:
+//	  tls:
+//	    mode: ISTIO_MUTUAL
 type TLSSettings struct {
 
 	// REQUIRED: Indicates whether connections to this port should be secured

--- a/pkg/apis/istio/v1alpha3/virtual_service.go
+++ b/pkg/apis/istio/v1alpha3/virtual_service.go
@@ -30,31 +30,34 @@ type VirtualService struct {
 // HTTP requests with path starting with /wpcatalog/ or /consumercatalog/ will
 // be rewritten to /newcatalog and sent to pods with label "version: v2".
 //
-//
 // ```yaml
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: reviews-route
+//
+//	name: reviews-route
+//
 // spec:
-//   hosts:
-//   - reviews.prod.svc.cluster.local
-//   http:
-//   - match:
-//     - uri:
-//         prefix: "/wpcatalog"
-//     - uri:
-//         prefix: "/consumercatalog"
-//     rewrite:
-//       uri: "/newcatalog"
-//     route:
-//     - destination:
-//         host: reviews.prod.svc.cluster.local
-//         subset: v2
-//   - route:
-//     - destination:
-//         host: reviews.prod.svc.cluster.local
-//         subset: v1
+//
+//	hosts:
+//	- reviews.prod.svc.cluster.local
+//	http:
+//	- match:
+//	  - uri:
+//	      prefix: "/wpcatalog"
+//	  - uri:
+//	      prefix: "/consumercatalog"
+//	  rewrite:
+//	    uri: "/newcatalog"
+//	  route:
+//	  - destination:
+//	      host: reviews.prod.svc.cluster.local
+//	      subset: v2
+//	- route:
+//	  - destination:
+//	      host: reviews.prod.svc.cluster.local
+//	      subset: v1
+//
 // ```
 //
 // A subset/version of a route destination is identified with a reference
@@ -65,18 +68,21 @@ type VirtualService struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: reviews-destination
-// spec:
-//   host: reviews.prod.svc.cluster.local
-//   subsets:
-//   - name: v1
-//     labels:
-//       version: v1
-//   - name: v2
-//     labels:
-//       version: v2
-// ```
 //
+//	name: reviews-destination
+//
+// spec:
+//
+//	host: reviews.prod.svc.cluster.local
+//	subsets:
+//	- name: v1
+//	  labels:
+//	    version: v1
+//	- name: v2
+//	  labels:
+//	    version: v2
+//
+// ```
 type VirtualServiceSpec struct {
 	// REQUIRED. The destination hosts to which traffic is being sent. Could
 	// be a DNS name with wildcard prefix or an IP address.  Depending on the
@@ -153,46 +159,54 @@ type VirtualServiceSpec struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: reviews-route
-//   namespace: foo
+//
+//	name: reviews-route
+//	namespace: foo
+//
 // spec:
-//   hosts:
-//   - reviews # interpreted as reviews.foo.svc.cluster.local
-//   http:
-//   - match:
-//     - uri:
-//         prefix: "/wpcatalog"
-//     - uri:
-//         prefix: "/consumercatalog"
-//     rewrite:
-//       uri: "/newcatalog"
-//     route:
-//     - destination:
-//         host: reviews # interpreted as reviews.foo.svc.cluster.local
-//         subset: v2
-//   - route:
-//     - destination:
-//         host: reviews # interpreted as reviews.foo.svc.cluster.local
-//         subset: v1
+//
+//	hosts:
+//	- reviews # interpreted as reviews.foo.svc.cluster.local
+//	http:
+//	- match:
+//	  - uri:
+//	      prefix: "/wpcatalog"
+//	  - uri:
+//	      prefix: "/consumercatalog"
+//	  rewrite:
+//	    uri: "/newcatalog"
+//	  route:
+//	  - destination:
+//	      host: reviews # interpreted as reviews.foo.svc.cluster.local
+//	      subset: v2
+//	- route:
+//	  - destination:
+//	      host: reviews # interpreted as reviews.foo.svc.cluster.local
+//	      subset: v1
+//
 // ```
 //
-// And the associated DestinationRule
+// # And the associated DestinationRule
 //
 // ```yaml
 // apiVersion: networking.istio.io/v1alpha3
 // kind: DestinationRule
 // metadata:
-//   name: reviews-destination
-//   namespace: foo
+//
+//	name: reviews-destination
+//	namespace: foo
+//
 // spec:
-//   host: reviews # interpreted as reviews.foo.svc.cluster.local
-//   subsets:
-//   - name: v1
-//     labels:
-//       version: v1
-//   - name: v2
-//     labels:
-//       version: v2
+//
+//	host: reviews # interpreted as reviews.foo.svc.cluster.local
+//	subsets:
+//	- name: v1
+//	  labels:
+//	    version: v1
+//	- name: v2
+//	  labels:
+//	    version: v2
+//
 // ```
 //
 // The following VirtualService sets a timeout of 5s for all calls to
@@ -209,16 +223,20 @@ type VirtualServiceSpec struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: my-productpage-rule
-//   namespace: istio-system
+//
+//	name: my-productpage-rule
+//	namespace: istio-system
+//
 // spec:
-//   hosts:
-//   - productpage.prod.svc.cluster.local # ignores rule namespace
-//   http:
-//   - timeout: 5s
-//     route:
-//     - destination:
-//         host: productpage.prod.svc.cluster.local
+//
+//	hosts:
+//	- productpage.prod.svc.cluster.local # ignores rule namespace
+//	http:
+//	- timeout: 5s
+//	  route:
+//	  - destination:
+//	      host: productpage.prod.svc.cluster.local
+//
 // ```
 //
 // To control routing for traffic bound to services outside the mesh, external
@@ -231,29 +249,36 @@ type VirtualServiceSpec struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: ServiceEntry
 // metadata:
-//   name: external-svc-wikipedia
+//
+//	name: external-svc-wikipedia
+//
 // spec:
-//   hosts:
-//   - wikipedia.org
-//   location: MESH_EXTERNAL
-//   ports:
-//   - number: 80
-//     name: example-http
-//     protocol: HTTP
-//   resolution: DNS
+//
+//	hosts:
+//	- wikipedia.org
+//	location: MESH_EXTERNAL
+//	ports:
+//	- number: 80
+//	  name: example-http
+//	  protocol: HTTP
+//	resolution: DNS
 //
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: my-wiki-rule
+//
+//	name: my-wiki-rule
+//
 // spec:
-//   hosts:
-//   - wikipedia.org
-//   http:
-//   - timeout: 5s
-//     route:
-//     - destination:
-//         host: wikipedia.org
+//
+//	hosts:
+//	- wikipedia.org
+//	http:
+//	- timeout: 5s
+//	  route:
+//	  - destination:
+//	      host: wikipedia.org
+//
 // ```
 type Destination struct {
 	// REQUIRED. The name of a service from the service registry. Service
@@ -374,23 +399,23 @@ type HeaderOperations struct {
 // starts with /ratings/v2/ and the request contains a "cookie" with value
 // "user=jason".
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: ratings-route
-//     spec:
-//       hosts:
-//       - ratings
-//       http:
-//       - match:
-//         - headers:
-//             cookie:
-//               regex: "^(.*?;)?(user=jason)(;.*)?"
-//             uri:
-//               prefix: "/ratings/v2/"
-//         route:
-//         - destination:
-//             host: ratings
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: ratings-route
+//	spec:
+//	  hosts:
+//	  - ratings
+//	  http:
+//	  - match:
+//	    - headers:
+//	        cookie:
+//	          regex: "^(.*?;)?(user=jason)(;.*)?"
+//	        uri:
+//	          prefix: "/ratings/v2/"
+//	    route:
+//	    - destination:
+//	        host: ratings
 //
 // HTTPMatchRequest CANNOT be empty.
 type HTTPMatchRequest struct {
@@ -536,19 +561,23 @@ type PortSelector struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: bookinfo-Mongo
+//
+//	name: bookinfo-Mongo
+//
 // spec:
-//   hosts:
-//   - mongo.prod.svc.cluster.local
-//   tcp:
-//   - match:
-//     - port: 27017
-//       sourceSubnet: "172.17.16.0/24"
-//     route:
-//     - destination:
-//         host: mongo.backup.svc.cluster.local
-//         port:
-//           number: 5555
+//
+//	hosts:
+//	- mongo.prod.svc.cluster.local
+//	tcp:
+//	- match:
+//	  - port: 27017
+//	    sourceSubnet: "172.17.16.0/24"
+//	  route:
+//	  - destination:
+//	      host: mongo.backup.svc.cluster.local
+//	      port:
+//	        number: 5555
+//
 // ```
 type TCPRoute struct {
 	// Match conditions to be satisfied for the rule to be
@@ -600,22 +629,21 @@ type L4MatchAttributes struct {
 // requests for /v1/getProductRatings API on the ratings service to
 // /v1/bookRatings provided by the bookratings service.
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: ratings-route
-//     spec:
-//       hosts:
-//       - ratings
-//       http:
-//       - match:
-//         - uri:
-//             exact: /v1/getProductRatings
-//       redirect:
-//         uri: /v1/bookRatings
-//         authority: bookratings.default.svc.cluster.local
-//       ...
-//
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: ratings-route
+//	spec:
+//	  hosts:
+//	  - ratings
+//	  http:
+//	  - match:
+//	    - uri:
+//	        exact: /v1/getProductRatings
+//	  redirect:
+//	    uri: /v1/bookRatings
+//	    authority: bookratings.default.svc.cluster.local
+//	  ...
 type HTTPRedirect struct {
 	// On a redirect, overwrite the Path portion of the URL with this
 	// value. Note that the entire path will be replaced, irrespective of the
@@ -633,24 +661,23 @@ type HTTPRedirect struct {
 // demonstrates how to rewrite the URL prefix for api call (/ratings) to
 // ratings service before making the actual API call.
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: ratings-route
-//     spec:
-//       hosts:
-//       - ratings
-//       http:
-//       - match:
-//         - uri:
-//             prefix: /ratings
-//         rewrite:
-//           uri: /v1/bookRatings
-//         route:
-//         - destination:
-//             host: ratings
-//             subset: v1
-//
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: ratings-route
+//	spec:
+//	  hosts:
+//	  - ratings
+//	  http:
+//	  - match:
+//	    - uri:
+//	        prefix: /ratings
+//	    rewrite:
+//	      uri: /v1/bookRatings
+//	    route:
+//	    - destination:
+//	        host: ratings
+//	        subset: v1
 type HTTPRewrite struct {
 	// rewrite the path (or the prefix) portion of the URI with this
 	// value. If the original URI was matched based on prefix, the value
@@ -669,21 +696,24 @@ type HTTPRewrite struct {
 // apiVersion: networking.istio.io/v1alpha3
 // kind: VirtualService
 // metadata:
-//   name: ratings-route
-// spec:
-//   hosts:
-//   - ratings.prod.svc.cluster.local
-//   http:
-//   - route:
-//     - destination:
-//         host: ratings.prod.svc.cluster.local
-//         subset: v1
-//     retries:
-//       attempts: 3
-//       perTryTimeout: 2s
-//       retryOn: gateway-error,connect-failure,refused-stream
-// ```
 //
+//	name: ratings-route
+//
+// spec:
+//
+//	hosts:
+//	- ratings.prod.svc.cluster.local
+//	http:
+//	- route:
+//	  - destination:
+//	      host: ratings.prod.svc.cluster.local
+//	      subset: v1
+//	  retries:
+//	    attempts: 3
+//	    perTryTimeout: 2s
+//	    retryOn: gateway-error,connect-failure,refused-stream
+//
+// ```
 type HTTPRetry struct {
 	// REQUIRED. Number of retries for a given request. The interval
 	// between retries will be determined automatically (25ms+). Actual
@@ -710,29 +740,28 @@ type HTTPRetry struct {
 // Access-Control-Allow-Credentials header to false. In addition, it only
 // exposes X-Foo-bar header and sets an expiry period of 1 day.
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: ratings-route
-//     spec:
-//       hosts:
-//       - ratings
-//       http:
-//       - route:
-//         - destination:
-//             host: ratings
-//             subset: v1
-//         corsPolicy:
-//           allowOrigin:
-//           - example.com
-//           allowMethods:
-//           - POST
-//           - GET
-//           allowCredentials: false
-//           allowHeaders:
-//           - X-Foo-Bar
-//           maxAge: "1d"
-//
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: ratings-route
+//	spec:
+//	  hosts:
+//	  - ratings
+//	  http:
+//	  - route:
+//	    - destination:
+//	        host: ratings
+//	        subset: v1
+//	    corsPolicy:
+//	      allowOrigin:
+//	      - example.com
+//	      allowMethods:
+//	      - POST
+//	      - GET
+//	      allowCredentials: false
+//	      allowHeaders:
+//	      - X-Foo-Bar
+//	      maxAge: "1d"
 type CorsPolicy struct {
 	// The list of origins that are allowed to perform CORS requests. The
 	// content will be serialized into the Access-Control-Allow-Origin
@@ -790,25 +819,25 @@ type HTTPFaultInjection struct {
 // in 10% of the requests to the "v1" version of the "reviews"
 // service from all pods with label env: prod
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: reviews-route
-//     spec:
-//       hosts:
-//       - reviews
-//       http:
-//       - match:
-//         - sourceLabels:
-//             env: prod
-//         route:
-//         - destination:
-//             host: reviews
-//             subset: v1
-//         fault:
-//           delay:
-//             percent: 10
-//             fixedDelay: 5s
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: reviews-route
+//	spec:
+//	  hosts:
+//	  - reviews
+//	  http:
+//	  - match:
+//	    - sourceLabels:
+//	        env: prod
+//	    route:
+//	    - destination:
+//	        host: reviews
+//	        subset: v1
+//	    fault:
+//	      delay:
+//	        percent: 10
+//	        fixedDelay: 5s
 //
 // The _fixedDelay_ field is used to indicate the amount of delay in
 // seconds. An optional _percent_ field, a value between 0 and 100, can
@@ -832,22 +861,22 @@ type InjectDelay struct {
 // pre-specified error code. The following example will return an HTTP
 // 400 error code for 10% of the requests to the "ratings" service "v1".
 //
-//     apiVersion: networking.istio.io/v1alpha3
-//     kind: VirtualService
-//     metadata:
-//       name: ratings-route
-//     spec:
-//       hosts:
-//       - ratings
-//       http:
-//       - route:
-//         - destination:
-//             host: ratings
-//             subset: v1
-//         fault:
-//           abort:
-//             percent: 10
-//             httpStatus: 400
+//	apiVersion: networking.istio.io/v1alpha3
+//	kind: VirtualService
+//	metadata:
+//	  name: ratings-route
+//	spec:
+//	  hosts:
+//	  - ratings
+//	  http:
+//	  - route:
+//	    - destination:
+//	        host: ratings
+//	        subset: v1
+//	    fault:
+//	      abort:
+//	        percent: 10
+//	        httpStatus: 400
 //
 // The _httpStatus_ field is used to indicate the HTTP status code to
 // return to the caller. The optional _percent_ field, a value between 0

--- a/pkg/apis/projectcontour/v1/detailedconditions.go
+++ b/pkg/apis/projectcontour/v1/detailedconditions.go
@@ -107,7 +107,9 @@ type SubCondition struct {
 // slice in this case.
 //
 // `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
-//  The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+//
+//	The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+//
 // slice if `status` is `false`.
 //
 // For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -337,7 +337,7 @@ func (c *DaemonSetController) HaveDependenciesChanged(cd *flaggerv1.Canary) (boo
 	return c.configTracker.HasConfigChanged(cd)
 }
 
-//Finalize scale the reference instance from zero
+// Finalize scale the reference instance from zero
 func (c *DaemonSetController) Finalize(cd *flaggerv1.Canary) error {
 	if err := c.ScaleFromZero(cd); err != nil {
 		return fmt.Errorf("ScaleFromZero failed: %w", err)

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -63,14 +63,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -63,14 +63,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/metrics/observers/kuma.go
+++ b/pkg/metrics/observers/kuma.go
@@ -25,8 +25,9 @@ import (
 )
 
 // TODO [@johnharris85]: Do we also need to select by mesh here? These could be duplicated (but in different meshes).
-// 	We're currently getting the mesh name from an annotation on the Canary object, but that isn't propagated to the
-// 	MetricTemplateModel.
+//
+//	We're currently getting the mesh name from an annotation on the Canary object, but that isn't propagated to the
+//	MetricTemplateModel.
 var kumaQueries = map[string]string{
 	"request-success-rate": `
 	sum(

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -190,7 +190,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 
 	// create destinations with canary weight when trafficType is 2
 	if traffictype == 2 {
-	
+
 		canaryRoute = []istiov1alpha3.DestinationWeight{
 			makeDestination(canary, canaryName, 0),
 		}

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -190,6 +190,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 
 	// create destinations with canary weight when trafficType is 2
 	if traffictype == 2 {
+	
 		canaryRoute = []istiov1alpha3.DestinationWeight{
 			makeDestination(canary, canaryName, 0),
 		}


### PR DESCRIPTION
Hi,there:
   During canary deployment I want to add a policy of traffic forwarding based on header, that is access with header only to canary instance and others to primary and canary  as follows.
<img width="499" alt="image" src="https://user-images.githubusercontent.com/24687834/184580712-4c3c965c-d2e7-4533-bb0e-94844ecc6bad.png">
  So I added a flag (trafficType) in the CRD to identify the traffic distribution policy. and update istio.go.
  This is a requirement of our business and I think there are many other users who also want to use this traffic forwarding strategy(https://github.com/fluxcd/flagger/issues/840). Can you add this function to it. Thank you very much
  

Signed-off-by: Henry He [kuahe@cisco.com](mailto:kuahe@cisco.com)