### PR TITLE
Add `app.kubernetes.io/version` label to chart

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ template "flagger.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
   replicas: {{ .Values.leaderElection.replicaCount }}
   {{- if eq .Values.leaderElection.enabled false }}
@@ -22,6 +23,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "flagger.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
       {{- if .Values.podLabels }}
       {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Add `app.kubernetes.io/version` label as described in https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

This is useful if you have many deployments in different clusters and want to be able to monitor what versions you have deployed using something like `kube_pod_labels` from kube-state-metrics.

Signed-off-by: Gustaf Lindstedt <gustaf.lindstedt@embark-studios.com>