### PR TITLE
logCmdOutput to logger instead of stdout

### DIFF
--- a/pkg/loadtester/bash.go
+++ b/pkg/loadtester/bash.go
@@ -43,7 +43,7 @@ func (task *BashTask) Run(ctx context.Context) (*TaskRunResult, error) {
 		return &TaskRunResult{false, out}, fmt.Errorf("command %s failed: %s: %w", task.command, out, err)
 	} else {
 		if task.logCmdOutput {
-			fmt.Printf("%s\n", out)
+			task.logger.With("canary", task.canary).Info(string(out))
 		}
 		task.logger.With("canary", task.canary).Infof("command finished %s", task.command)
 	}

--- a/pkg/loadtester/helmv3.go
+++ b/pkg/loadtester/helmv3.go
@@ -47,7 +47,7 @@ func (task *HelmTaskv3) Run(ctx context.Context) (*TaskRunResult, error) {
 		return &TaskRunResult{false, out}, fmt.Errorf("command %s failed: %s: %w", task.command, out, err)
 	} else {
 		if task.logCmdOutput {
-			fmt.Printf("%s\n", out)
+			task.logger.With("canary", task.canary).Info(string(out))
 		}
 		task.logger.With("canary", task.canary).Infof("command finished %v", helmCmd)
 	}

--- a/pkg/loadtester/task_shell.go
+++ b/pkg/loadtester/task_shell.go
@@ -19,7 +19,6 @@ package loadtester
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strconv"
 
@@ -57,7 +56,7 @@ func (task *CmdTask) Run(ctx context.Context) *TaskRunResult {
 		task.logger.With("canary", task.canary).Errorf("command failed %s %v %s", task.command, err, out)
 	} else {
 		if task.logCmdOutput {
-			fmt.Printf("%s\n", out)
+			task.logger.With("canary", task.canary).Info(string(out))
 		}
 		task.logger.With("canary", task.canary).Infof("command finished %s", task.command)
 	}


### PR DESCRIPTION
To be able to keep log context use logger instead of stdout. 

Signed-off-by: Øistein Sletten Løvik <oistein@oistein.org>