### PR TITLE
Include cluster name in all alerts

### DIFF
--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -73,8 +73,18 @@ func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template
 
 func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bool, severity flaggerv1.AlertSeverity) {
 	var fields []notifier.Field
+
+	if c.clusterName != "" {
+		fields = append(fields,
+			notifier.Field{
+				Name:  "Cluster",
+				Value: c.clusterName,
+			},
+		)
+	}
+
 	if metadata {
-		fields = alertMetadata(canary, c.clusterName)
+		fields = alertMetadata(canary)
 	}
 
 	// send alert with the global notifier
@@ -173,17 +183,8 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 	}
 }
 
-func alertMetadata(canary *flaggerv1.Canary, cluster string) []notifier.Field {
+func alertMetadata(canary *flaggerv1.Canary) []notifier.Field {
 	var fields []notifier.Field
-
-	if cluster != "" {
-		fields = append(fields,
-			notifier.Field{
-				Name:  "Cluster",
-				Value: cluster,
-			},
-		)
-	}
 
 	fields = append(fields,
 		notifier.Field{


### PR DESCRIPTION
We have a single Slack channel to send all notifications from all environments.  A few alert messages can't be identified from which environment.

```
x-service.namespace
Canary analysis completed successfully, promotion finished.

y-service.namespace
Canary analysis completed successfully, promotion finished.

z-service.namespace
Canary analysis completed successfully, promotion finished.
```

I want to include the cluster name in all alerts so the expected behaviour
```
x-service.namespace
Cluster
ClusterName
Canary analysis completed successfully, promotion finished.

y-service.namespace
Cluster
ClusterName
Canary analysis completed successfully, promotion finished.

z-service.namespace
Cluster
ClusterName
Canary analysis completed successfully, promotion finished.
```

Signed-off-by: ashokhein <ashokhein@gmail.com>