### PR TITLE
gatewayapi: fix reconcilation of nil hostnames

### DIFF
--- a/pkg/router/gateway_api.go
+++ b/pkg/router/gateway_api.go
@@ -66,7 +66,7 @@ func (gwr *GatewayAPIRouter) Reconcile(canary *flaggerv1.Canary) error {
 
 	hrNamespace := canary.Namespace
 
-	hostNames := []v1alpha2.Hostname{}
+	var hostNames []v1alpha2.Hostname
 	for _, host := range canary.Spec.Service.Hosts {
 		hostNames = append(hostNames, v1alpha2.Hostname(host))
 	}
@@ -179,7 +179,7 @@ func (gwr *GatewayAPIRouter) Reconcile(canary *flaggerv1.Canary) error {
 				return fmt.Errorf("HTTPRoute %s.%s update error: %w while reconciling", hrClone.GetName(), hrNamespace, err)
 			}
 			gwr.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
-				Infof("HTTPProxy %s.%s updated", hrClone.GetName(), hrNamespace)
+				Infof("HTTPRoute %s.%s updated", hrClone.GetName(), hrNamespace)
 		}
 	}
 


### PR DESCRIPTION
`go-cmp/cmp` differentiates between `[]string{}` and `nil`, which causes problems during reconciliation when `.spec.service.hostnames` is left blank in the Canary object.

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>