### PR TITLE
fix(gloo): Use correct route table name in case service name was overwritten

### DIFF
--- a/pkg/router/gloo.go
+++ b/pkg/router/gloo.go
@@ -170,9 +170,8 @@ func (gr *GlooRouter) GetRoutes(canary *flaggerv1.Canary) (
 	mirrored bool,
 	err error,
 ) {
-	apexName := canary.Spec.TargetRef.Name
-	primaryName := fmt.Sprintf("%s-%s-primaryupstream-%v", canary.Namespace, canary.Spec.TargetRef.Name, canary.Spec.Service.Port)
-
+	apexName, _, _ := canary.GetServiceNames()
+	primaryUpstreamName := fmt.Sprintf("%s-%s-primaryupstream-%v", canary.Namespace, apexName, canary.Spec.Service.Port)
 	routeTable, err := gr.glooClient.GatewayV1().RouteTables(canary.Namespace).Get(context.TODO(), apexName, metav1.GetOptions{})
 	if err != nil {
 		err = fmt.Errorf("RouteTable %s.%s get query error: %w", apexName, canary.Namespace, err)
@@ -185,7 +184,7 @@ func (gr *GlooRouter) GetRoutes(canary *flaggerv1.Canary) (
 	}
 
 	for _, dst := range routeTable.Spec.Routes[0].Action.Destination.Destinations {
-		if dst.Destination.Upstream.Name == primaryName {
+		if dst.Destination.Upstream.Name == primaryUpstreamName {
 			primaryWeight = int(dst.Weight)
 			canaryWeight = 100 - primaryWeight
 			return

--- a/test/gloo/install.sh
+++ b/test/gloo/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-GLOO_VER="1.11.13"
+GLOO_VER="1.12.31"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin

--- a/test/gloo/install.sh
+++ b/test/gloo/install.sh
@@ -15,7 +15,6 @@ helm upgrade -i gloo gloo/gloo --version ${GLOO_VER} \
 --set discovery.enabled=false
 
 kubectl -n gloo-system rollout status deployment/gloo
-kubectl -n gloo-system rollout status deployment/gateway
 kubectl -n gloo-system get all
 
 echo '>>> Installing Flagger'


### PR DESCRIPTION
Steps to reproduce bug:
* Create `Canary` resource with `service.name` set and provider `gloo`
For example:
```yaml
  provider: gloo 
  service:
    name: podinfo-flagger
```
* flagger will create `RouteTable` with name `podinfo-flagger`
* But then in logs it will error that `query error: routetables.gateway.solo.io` for name `podinfo`

This PR will use same func and names for `GetRoutes` as for `Reconcile`.

PR contains:
* fix for issue
* update gloo helm chart to latest stable `1.12.31`
* remove check for `gateway` deployment in tests. Because gateway functionality is removed from a standalone pod, and is now included in the Gloo Edge control plane pod. https://docs.solo.io/gloo-edge/latest/operations/upgrading/v1.12/
