### PR TITLE
fix(faq): Update FAQ about zero downtime with correct values

### DIFF
--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -69,8 +69,8 @@ spec:
 #### Why is there a window of downtime during the canary initializing process when analysis is disabled?
 
 A window of downtime is the intended behavior when the analysis is disabled. This allows instant rollback and also mimics the way
-a Kubernetes deployment initialization works. To avoid this, enable the analysis (`skipAnalysis: true`), wait for the initialization
-to finish, and disable it afterward (`skipAnalysis: false`).
+a Kubernetes deployment initialization works. To avoid this, enable the analysis (`skipAnalysis: false`), wait for the initialization
+to finish, and disable it afterward (`skipAnalysis: true`).
 
 #### How to disable cross namespace references?
 


### PR DESCRIPTION
* Based on  text and this code https://github.com/fluxcd/flagger/blob/main/pkg/canary/deployment_controller.go#L56 i think that to prevent downtime we need to set `skipAnalysis: false`