### PR TITLE
Fixing cluster name

### DIFF
--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -84,7 +84,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 	}
 
 	if metadata {
-		fields = alertMetadata(canary)
+		fields = append(fields, alertMetadata(canary)...)
 	}
 
 	// send alert with the global notifier


### PR DESCRIPTION
I was trying to add a cluster name (https://github.com/fluxcd/flagger/pull/1275) in all alerts, but it didn't realize that alertMetadata func creates new fields, so it is missing the cluster name whenever the metadata var is true 

Signed-off-by: ashokhein <ashokhein@gmail.com>