### PR TITLE
Allow access to Prometheus in OpenShift via SA token

### DIFF
--- a/docs/gitbook/usage/metrics.md
+++ b/docs/gitbook/usage/metrics.md
@@ -184,11 +184,23 @@ as the `MetricTemplate` with the basic-auth credentials:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: prom-basic-auth
+  name: prom-auth
   namespace: flagger
 data:
   username: your-user
   password: your-password
+```
+
+or if you require bearer token authentication (via a SA token):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prom-auth
+  namespace: flagger
+data:
+  token: ey1234...
 ```
 
 Then reference the secret in the `MetricTemplate`:
@@ -204,7 +216,7 @@ spec:
     type: prometheus
     address: http://prometheus.monitoring:9090
     secretRef:
-      name: prom-basic-auth
+      name: prom-auth
 ```
 
 ## Datadog


### PR DESCRIPTION
Fixes: https://github.com/fluxcd/flagger/issues/1064

We can already access prometheus using Basic Auth. This PR adds support to access prometheus using Authorization: Bearer token too.



Signed-off-by: Wallace Wadge <wwadge@gmail.com>