### PR TITLE
Ignoring Primary desiredReplicas sync from Canary desiredReplicas

### DIFF
--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -106,9 +106,9 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 		primaryCopy.Spec.RevisionHistoryLimit = canary.Spec.RevisionHistoryLimit
 		primaryCopy.Spec.Strategy = canary.Spec.Strategy
 		// update replica if hpa isn't set
-		if cd.Spec.AutoscalerRef == nil {
-			primaryCopy.Spec.Replicas = canary.Spec.Replicas
-		}
+		// if cd.Spec.AutoscalerRef == nil {
+		//	primaryCopy.Spec.Replicas = canary.Spec.Replicas
+		// }
 
 		// update spec with primary secrets and config maps
 		primaryCopy.Spec.Template.Spec = c.getPrimaryDeploymentTemplateSpec(canary, configRefs)


### PR DESCRIPTION
Fixes - #1347 

Ref - https://docs.flagger.app/usage/how-it-works

The autoscaler reference is optional, when specified, Flagger will pause the traffic increase while the target and primary deployments are scaled up or down. HPA can help reduce the resource usage during the canary analysis. When the autoscaler reference is specified, any changes made to the autoscaler are only made active in the primary autoscaler when a rollout for the deployment starts and completes successfully. Optionally, you can create two HPAs, one for canary and one for the primary to update the HPA without doing a new rollout. As the canary deployment will be scaled to 0, the HPA on the canary will be inactive.

Q. Why we wanted to use 2 explicit HPAs?
A. Use Case - If our HPA had minReplicas = 100, maxReplicas = 200 and currently desiredReplicas = 150, then during deployment Flagger will setup Canary HPA's minReplicas = 100, which will cause DB Pool Connection throttling. Hence, on using 2 different HPAs for Canary and Primary, we can define minReplicas for canary HPA.

Issue - On using 2 explicit HPAs, during canary, Primary Replicas = Canary Replicas.
Example - 

Canary HPA -

- minReplicas - 1
- maxReplicas - 10
- desiredReplicas - 5

Primary HPA -

-   minReplicas - 100
-   maxReplicas - 200
-   desiredReplicas - 150

So, after Canary Analysis, Primary HPA's desiredReplicas = Canary HPA's desiredReplicas. Now, our production live app will have Primary HPA's desiredReplicas = 5, hence our app which was being served by 150 pods, now will be served by only 5 pods. Hence, total production downtime.