### PR TITLE
use regex to match against headers in istio

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -443,10 +444,11 @@ func (ir *IstioRouter) SetRoutes(
 				weightedRoute.Route[i] = routeDest
 			}
 
+			cookieKeyAndVal := strings.Split(canary.Status.SessionAffinityCookie, "=")
 			cookieMatch := istiov1alpha3.HTTPMatchRequest{
 				Headers: map[string]istiov1alpha1.StringMatch{
 					cookieHeader: {
-						Exact: canary.Status.SessionAffinityCookie,
+						Regex: fmt.Sprintf(".*%s.*%s.*", cookieKeyAndVal[0], cookieKeyAndVal[1]),
 					},
 				},
 			}
@@ -465,10 +467,11 @@ func (ir *IstioRouter) SetRoutes(
 
 			// Match against the previous session cookie and delete that cookie
 			if previousCookie != "" {
+				cookieKeyAndVal := strings.Split(previousCookie, "=")
 				cookieMatch := istiov1alpha3.HTTPMatchRequest{
 					Headers: map[string]istiov1alpha1.StringMatch{
 						cookieHeader: {
-							Exact: previousCookie,
+							Regex: fmt.Sprintf(".*%s.*%s.*", cookieKeyAndVal[0], cookieKeyAndVal[1]),
 						},
 					},
 				}

--- a/pkg/router/istio_test.go
+++ b/pkg/router/istio_test.go
@@ -166,7 +166,7 @@ func TestIstioRouter_SetRoutes(t *testing.T) {
 		for _, match := range stickyRoute.Match {
 			if val, ok := match.Headers[cookieHeader]; ok {
 				found = true
-				assert.True(t, strings.HasPrefix(val.Exact, cookieKey))
+				assert.True(t, strings.Contains(val.Regex, cookieKey))
 				for _, routeDest := range stickyRoute.Route {
 					if routeDest.Destination.Host == pHost {
 						assert.Equal(t, 0, routeDest.Weight)
@@ -223,7 +223,7 @@ func TestIstioRouter_SetRoutes(t *testing.T) {
 		for _, match := range stickyRoute.Match {
 			if val, ok := match.Headers[cookieHeader]; ok {
 				found = true
-				assert.True(t, strings.HasPrefix(val.Exact, cookieKey))
+				assert.True(t, strings.Contains(val.Regex, cookieKey))
 				for _, routeDest := range stickyRoute.Route {
 					if routeDest.Destination.Host == pHost {
 						assert.Equal(t, 0, routeDest.Weight)
@@ -266,7 +266,7 @@ func TestIstioRouter_SetRoutes(t *testing.T) {
 		for _, match := range stickyRoute.Match {
 			if val, ok := match.Headers[cookieHeader]; ok {
 				found = true
-				assert.True(t, strings.HasPrefix(val.Exact, cookieKey))
+				assert.True(t, strings.Contains(val.Regex, cookieKey))
 				for _, routeDest := range stickyRoute.Route {
 					if routeDest.Destination.Host == pHost {
 						assert.Equal(t, 100, routeDest.Weight)


### PR DESCRIPTION
Use regex filtering to match against session affinity cookie headers when using Istio instead of an exact match.

Fixes: #1339 
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>