### PR TITLE
Initial support for progressive initialization

### DIFF
--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -91,7 +91,7 @@ func (c *DaemonSetController) ScaleFromZero(cd *flaggerv1.Canary) error {
 	return nil
 }
 
-// Initialize creates the primary DaemonSet, scales down the canary DaemonSet,
+// Initialize creates the primary DaemonSet, scales down the canary DaemonSet unless progressive initialization is enabled,
 // and returns the pod selector label and container ports
 func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary) (err error) {
 	err = c.createPrimaryDaemonSet(cd, c.includeLabelPrefix)

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -52,17 +52,19 @@ func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
 	}
 
-	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
+	if cd.InitializingPhase() {
 		if !cd.SkipAnalysis() {
 			if err := c.IsPrimaryReady(cd); err != nil {
 				return fmt.Errorf("%w", err)
 			}
 		}
 
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
-			Infof("Scaling down Deployment %s.%s", cd.Spec.TargetRef.Name, cd.Namespace)
-		if err := c.ScaleToZero(cd); err != nil {
-			return fmt.Errorf("scaling down canary deployment %s.%s failed: %w", cd.Spec.TargetRef.Name, cd.Namespace, err)
+		if !cd.Spec.ProgressiveInitialization {
+			c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+				Infof("Scaling down Deployment %s.%s", cd.Spec.TargetRef.Name, cd.Namespace)
+			if err := c.ScaleToZero(cd); err != nil {
+				return fmt.Errorf("scaling down canary deployment %s.%s failed: %w", cd.Spec.TargetRef.Name, cd.Namespace, err)
+			}
 		}
 	}
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -46,7 +46,8 @@ type DeploymentController struct {
 }
 
 // Initialize creates the primary deployment, hpa,
-// scales to zero the canary deployment and returns the pod selector label and container ports
+// scales to zero the canary deployment unless progressive initialization is enabled,
+// and returns the pod selector label and container ports
 func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 	if err := c.createPrimaryDeployment(cd, c.includeLabelPrefix); err != nil {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -897,7 +897,7 @@ func (c *Controller) checkInitializingCanaryStatus(canary *flaggerv1.Canary, can
 			true, flaggerv1.SeverityInfo)
 		return true
 	} else {
-		return true
+		return false
 	}
 }
 

--- a/pkg/router/apisix.go
+++ b/pkg/router/apisix.go
@@ -70,14 +70,13 @@ func (ar *ApisixRouter) Reconcile(canary *flaggerv1.Canary) error {
 	}
 
 	targetHttpRoute.Priority = maxPriority
+	primaryWeight, canaryWeight := initializationWeights(canary)
 
 	primaryBackend := targetHttpRoute.Backends[0]
 	primaryBackend.ServiceName = primaryName
-	primaryWeight := 100
 	primaryBackend.Weight = &primaryWeight
 	targetHttpRoute.Backends[0] = primaryBackend
 
-	canaryWeight := 0
 	canaryBackend := a6v2.ApisixRouteHTTPBackend{
 		ServiceName:        canaryName,
 		ServicePort:        primaryBackend.ServicePort,

--- a/pkg/router/apisix_test.go
+++ b/pkg/router/apisix_test.go
@@ -86,3 +86,68 @@ func TestApisixRouter_GetSetRoutes(t *testing.T) {
 	assert.Equal(t, 50, *arRouter.Spec.HTTP[0].Backends[0].Weight)
 	assert.Equal(t, 50, *arRouter.Spec.HTTP[0].Backends[1].Weight)
 }
+
+func TestApisixRouter_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	mocks.canary.Spec.RouteRef = &v1beta1.LocalObjectReference{
+		Name:       "podinfo",
+		Kind:       "ApisixRoute",
+		APIVersion: "apisix.apache.org/v2",
+	}
+	router := &ApisixRouter{
+		apisixClient: mocks.flaggerClient,
+		logger:       mocks.logger,
+	}
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestApisixRouter_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	mocks.canary.Spec.RouteRef = &v1beta1.LocalObjectReference{
+		Name:       "podinfo",
+		Kind:       "ApisixRoute",
+		APIVersion: "apisix.apache.org/v2",
+	}
+	router := &ApisixRouter{
+		apisixClient: mocks.flaggerClient,
+		logger:       mocks.logger,
+	}
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -49,6 +49,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 	const annotation = "projectcontour.io/ingress.class"
 
 	apexName, primaryName, canaryName := canary.GetServiceNames()
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 
 	newSpec := contourv1.HTTPProxySpec{
 		Routes: []contourv1.Route{
@@ -64,7 +65,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 					{
 						Name:   primaryName,
 						Port:   int(canary.Spec.Service.Port),
-						Weight: int64(100),
+						Weight: int64(initialPrimaryWeight),
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, primaryName),
@@ -74,7 +75,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 					{
 						Name:   canaryName,
 						Port:   int(canary.Spec.Service.Port),
-						Weight: int64(0),
+						Weight: int64(initialCanaryWeight),
 						RequestHeadersPolicy: &contourv1.HeadersPolicy{
 							Set: []contourv1.HeaderValue{
 								cr.makeLinkerdHeaderValue(canary, canaryName),

--- a/pkg/router/contour_test.go
+++ b/pkg/router/contour_test.go
@@ -156,3 +156,62 @@ func TestContourRouter_Routes(t *testing.T) {
 	primary = proxy.Spec.Routes[1].Services[0]
 	assert.Equal(t, int64(100), primary.Weight)
 }
+
+func TestContourRouter_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &ContourRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		contourClient: mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestContourRouter_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &ContourRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		contourClient: mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/gateway_api.go
+++ b/pkg/router/gateway_api.go
@@ -36,19 +36,17 @@ import (
 )
 
 var (
-	initialPrimaryWeight = int32(100)
-	initialCanaryWeight  = int32(0)
-	backendRefGroup      = ""
-	backendRefKind       = "Service"
-	pathMatchValue       = "/"
-	pathMatchType        = v1alpha2.PathMatchPathPrefix
-	pathMatchRegex       = v1alpha2.PathMatchRegularExpression
-	pathMatchExact       = v1alpha2.PathMatchExact
-	pathMatchPrefix      = v1alpha2.PathMatchPathPrefix
-	headerMatchExact     = v1alpha2.HeaderMatchExact
-	headerMatchRegex     = v1alpha2.HeaderMatchRegularExpression
-	queryMatchExact      = v1alpha2.QueryParamMatchExact
-	queryMatchRegex      = v1alpha2.QueryParamMatchRegularExpression
+	backendRefGroup  = ""
+	backendRefKind   = "Service"
+	pathMatchValue   = "/"
+	pathMatchType    = v1alpha2.PathMatchPathPrefix
+	pathMatchRegex   = v1alpha2.PathMatchRegularExpression
+	pathMatchExact   = v1alpha2.PathMatchExact
+	pathMatchPrefix  = v1alpha2.PathMatchPathPrefix
+	headerMatchExact = v1alpha2.HeaderMatchExact
+	headerMatchRegex = v1alpha2.HeaderMatchRegularExpression
+	queryMatchExact  = v1alpha2.QueryParamMatchExact
+	queryMatchRegex  = v1alpha2.QueryParamMatchRegularExpression
 )
 
 type GatewayAPIRouter struct {
@@ -84,6 +82,8 @@ func (gwr *GatewayAPIRouter) Reconcile(canary *flaggerv1.Canary) error {
 		})
 	}
 
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
+
 	httpRouteSpec := v1alpha2.HTTPRouteSpec{
 		CommonRouteSpec: v1alpha2.CommonRouteSpec{
 			ParentRefs: toV1alpha2ParentRefs(canary.Spec.Service.GatewayRefs),
@@ -94,10 +94,10 @@ func (gwr *GatewayAPIRouter) Reconcile(canary *flaggerv1.Canary) error {
 				Matches: matches,
 				BackendRefs: []v1alpha2.HTTPBackendRef{
 					{
-						BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+						BackendRef: gwr.makeBackendRef(primarySvcName, int32(initialPrimaryWeight), canary.Spec.Service.Port),
 					},
 					{
-						BackendRef: gwr.makeBackendRef(canarySvcName, initialCanaryWeight, canary.Spec.Service.Port),
+						BackendRef: gwr.makeBackendRef(canarySvcName, int32(initialCanaryWeight), canary.Spec.Service.Port),
 					},
 				},
 			},
@@ -113,7 +113,7 @@ func (gwr *GatewayAPIRouter) Reconcile(canary *flaggerv1.Canary) error {
 			Matches: matches,
 			BackendRefs: []v1alpha2.HTTPBackendRef{
 				{
-					BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+					BackendRef: gwr.makeBackendRef(primarySvcName, 100, canary.Spec.Service.Port),
 				},
 			},
 		})
@@ -277,7 +277,7 @@ func (gwr *GatewayAPIRouter) SetRoutes(
 			Matches: matches,
 			BackendRefs: []v1alpha2.HTTPBackendRef{
 				{
-					BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+					BackendRef: gwr.makeBackendRef(primarySvcName, 100, canary.Spec.Service.Port),
 				},
 			},
 		})

--- a/pkg/router/gateway_api_test.go
+++ b/pkg/router/gateway_api_test.go
@@ -70,3 +70,60 @@ func TestGatewayAPIRouter_Routes(t *testing.T) {
 	primary := httpRoute.Spec.Rules[0].BackendRefs[0]
 	assert.Equal(t, int32(50), *primary.Weight)
 }
+
+func TestGatewayAPIRouter_ProgressiveInit(t *testing.T) {
+	canary := newTestGatewayAPICanary()
+	mocks := newFixture(canary)
+	router := &GatewayAPIRouter{
+		gatewayAPIClient: mocks.meshClient,
+		kubeClient:       mocks.kubeClient,
+		logger:           mocks.logger,
+	}
+
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestGatewayAPIRouter_ProgressiveUpdate(t *testing.T) {
+	canary := newTestGatewayAPICanary()
+	mocks := newFixture(canary)
+	router := &GatewayAPIRouter{
+		gatewayAPIClient: mocks.meshClient,
+		kubeClient:       mocks.kubeClient,
+		logger:           mocks.logger,
+	}
+
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/gateway_api_v1beta1.go
+++ b/pkg/router/gateway_api_v1beta1.go
@@ -78,6 +78,8 @@ func (gwr *GatewayAPIV1Beta1Router) Reconcile(canary *flaggerv1.Canary) error {
 		})
 	}
 
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
+
 	httpRouteSpec := v1beta1.HTTPRouteSpec{
 		CommonRouteSpec: v1beta1.CommonRouteSpec{
 			ParentRefs: canary.Spec.Service.GatewayRefs,
@@ -88,10 +90,10 @@ func (gwr *GatewayAPIV1Beta1Router) Reconcile(canary *flaggerv1.Canary) error {
 				Matches: matches,
 				BackendRefs: []v1beta1.HTTPBackendRef{
 					{
-						BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+						BackendRef: gwr.makeBackendRef(primarySvcName, int32(initialPrimaryWeight), canary.Spec.Service.Port),
 					},
 					{
-						BackendRef: gwr.makeBackendRef(canarySvcName, initialCanaryWeight, canary.Spec.Service.Port),
+						BackendRef: gwr.makeBackendRef(canarySvcName, int32(initialCanaryWeight), canary.Spec.Service.Port),
 					},
 				},
 			},
@@ -107,7 +109,7 @@ func (gwr *GatewayAPIV1Beta1Router) Reconcile(canary *flaggerv1.Canary) error {
 			Matches: matches,
 			BackendRefs: []v1beta1.HTTPBackendRef{
 				{
-					BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+					BackendRef: gwr.makeBackendRef(primarySvcName, 100, canary.Spec.Service.Port),
 				},
 			},
 		})
@@ -271,7 +273,7 @@ func (gwr *GatewayAPIV1Beta1Router) SetRoutes(
 			Matches: matches,
 			BackendRefs: []v1beta1.HTTPBackendRef{
 				{
-					BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+					BackendRef: gwr.makeBackendRef(primarySvcName, 100, canary.Spec.Service.Port),
 				},
 			},
 		})

--- a/pkg/router/gateway_api_v1beta1_test.go
+++ b/pkg/router/gateway_api_v1beta1_test.go
@@ -70,3 +70,60 @@ func TestGatewayAPIV1Beta1Router_Routes(t *testing.T) {
 	primary := httpRoute.Spec.Rules[0].BackendRefs[0]
 	assert.Equal(t, int32(50), *primary.Weight)
 }
+
+func TestGatewayAPIV1Beta1Router_ProgressiveInit(t *testing.T) {
+	canary := newTestGatewayAPICanary()
+	mocks := newFixture(canary)
+	router := &GatewayAPIV1Beta1Router{
+		gatewayAPIClient: mocks.meshClient,
+		kubeClient:       mocks.kubeClient,
+		logger:           mocks.logger,
+	}
+
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestGatewayAPIV1Beta1Router_ProgressiveUpdate(t *testing.T) {
+	canary := newTestGatewayAPICanary()
+	mocks := newFixture(canary)
+	router := &GatewayAPIV1Beta1Router{
+		gatewayAPIClient: mocks.meshClient,
+		kubeClient:       mocks.kubeClient,
+		logger:           mocks.logger,
+	}
+
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/gloo.go
+++ b/pkg/router/gloo.go
@@ -65,6 +65,7 @@ func (gr *GlooRouter) Reconcile(canary *flaggerv1.Canary) error {
 		return fmt.Errorf("error creating flagger canary upstream: %w", err)
 	}
 
+	primaryWeight, canaryWeight := initializationWeights(canary)
 	newSpec := gatewayv1.RouteTableSpec{
 		Routes: []gatewayv1.Route{
 			{
@@ -80,7 +81,7 @@ func (gr *GlooRouter) Reconcile(canary *flaggerv1.Canary) error {
 										Namespace: canary.Namespace,
 									},
 								},
-								Weight: 100,
+								Weight: uint32(primaryWeight),
 							},
 							{
 								Destination: gatewayv1.Destination{
@@ -89,7 +90,7 @@ func (gr *GlooRouter) Reconcile(canary *flaggerv1.Canary) error {
 										Namespace: canary.Namespace,
 									},
 								},
-								Weight: 0,
+								Weight: uint32(canaryWeight),
 							},
 						},
 					},

--- a/pkg/router/gloo_test.go
+++ b/pkg/router/gloo_test.go
@@ -176,3 +176,80 @@ func TestGlooRouter_GetRoutes(t *testing.T) {
 	assert.Equal(t, 0, c)
 	assert.False(t, m)
 }
+
+func TestGlooRouter_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &GlooRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		glooClient:    mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+	svcRouter := &KubernetesDefaultRouter{
+		kubeClient:    mocks.kubeClient,
+		flaggerClient: mocks.flaggerClient,
+		logger:        mocks.logger,
+	}
+	err := svcRouter.Initialize(mocks.canary)
+	require.NoError(t, err)
+	err = svcRouter.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestGlooRouter_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &GlooRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		glooClient:    mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+	svcRouter := &KubernetesDefaultRouter{
+		kubeClient:    mocks.kubeClient,
+		flaggerClient: mocks.flaggerClient,
+		logger:        mocks.logger,
+	}
+	err := svcRouter.Initialize(mocks.canary)
+	require.NoError(t, err)
+	err = svcRouter.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -163,10 +163,11 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 		gateways = append(gateways, "mesh")
 	}
 
-	// create destinations with primary weight 100% and canary weight 0%
+	// create destinations with initial weights
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 	canaryRoute := []istiov1alpha3.HTTPRouteDestination{
-		makeDestination(canary, primaryName, 100),
-		makeDestination(canary, canaryName, 0),
+		makeDestination(canary, primaryName, initialPrimaryWeight),
+		makeDestination(canary, canaryName, initialCanaryWeight),
 	}
 
 	if canary.Spec.Service.Delegation {

--- a/pkg/router/kuma.go
+++ b/pkg/router/kuma.go
@@ -29,6 +29,7 @@ type KumaRouter struct {
 // Reconcile creates or updates the Kuma TrafficRoute
 func (kr *KumaRouter) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, primaryName, canaryName := canary.GetServiceNames()
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 
 	trSpec := kumav1alpha1.TrafficRouteSpec{
 		Sources: []*kumav1alpha1.Selector{
@@ -48,13 +49,13 @@ func (kr *KumaRouter) Reconcile(canary *flaggerv1.Canary) error {
 		Conf: &kumav1alpha1.TrafficRouteConf{
 			Split: []*kumav1alpha1.TrafficRouteSplit{
 				{
-					Weight: uint32(100),
+					Weight: uint32(initialPrimaryWeight),
 					Destination: map[string]string{
 						"kuma.io/service": fmt.Sprintf("%s_%s_svc_%d", primaryName, canary.Namespace, canary.Spec.Service.Port),
 					},
 				},
 				{
-					Weight: uint32(0),
+					Weight: uint32(initialCanaryWeight),
 					Destination: map[string]string{
 						"kuma.io/service": fmt.Sprintf("%s_%s_svc_%d", canaryName, canary.Namespace, canary.Spec.Service.Port),
 					},

--- a/pkg/router/skipper.go
+++ b/pkg/router/skipper.go
@@ -96,7 +96,11 @@ func (skp *SkipperRouter) Reconcile(canary *flaggerv1.Canary) error {
 		return fmt.Errorf("backend %s not found in ingress %s", apexSvcName, apexIngressName)
 	}
 
-	iClone.Annotations = skp.makeAnnotations(iClone.Annotations, map[string]int{primarySvcName: 100, canarySvcName: 0})
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
+	iClone.Annotations = skp.makeAnnotations(iClone.Annotations, map[string]int{
+		primarySvcName: initialPrimaryWeight,
+		canarySvcName:  initialCanaryWeight,
+	})
 	iClone.Name = canaryIngressName
 	iClone.Namespace = canary.Namespace
 	if skp.setOwnerRefs {

--- a/pkg/router/smi.go
+++ b/pkg/router/smi.go
@@ -48,6 +48,7 @@ type SmiRouter struct {
 // Reconcile creates or updates the SMI traffic split
 func (sr *SmiRouter) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, primaryName, canaryName := canary.GetServiceNames()
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 
 	var host string
 	if len(canary.Spec.Service.Hosts) > 0 {
@@ -61,11 +62,11 @@ func (sr *SmiRouter) Reconcile(canary *flaggerv1.Canary) error {
 		Backends: []smiv1alpha1.TrafficSplitBackend{
 			{
 				Service: canaryName,
-				Weight:  resource.NewQuantity(0, resource.DecimalExponent),
+				Weight:  resource.NewQuantity(int64(initialCanaryWeight), resource.DecimalExponent),
 			},
 			{
 				Service: primaryName,
-				Weight:  resource.NewQuantity(100, resource.DecimalExponent),
+				Weight:  resource.NewQuantity(int64(initialPrimaryWeight), resource.DecimalExponent),
 			},
 		},
 	}

--- a/pkg/router/smi_test.go
+++ b/pkg/router/smi_test.go
@@ -137,3 +137,62 @@ func TestSmiRouter_GetRoutes(t *testing.T) {
 	assert.Equal(t, 0, c)
 	assert.False(t, m)
 }
+
+func TestSmiRouter_ProgressiveInit(t *testing.T) {
+	canary := newTestSMICanary()
+	mocks := newFixture(canary)
+	router := &SmiRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestSmiRouter_ProgressiveUpdate(t *testing.T) {
+	canary := newTestSMICanary()
+	mocks := newFixture(canary)
+	router := &SmiRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/smi_v1alpha2.go
+++ b/pkg/router/smi_v1alpha2.go
@@ -46,6 +46,7 @@ type Smiv1alpha2Router struct {
 // Reconcile creates or updates the SMI traffic split
 func (sr *Smiv1alpha2Router) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, primaryName, canaryName := canary.GetServiceNames()
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 
 	var host string
 	if len(canary.Spec.Service.Hosts) > 0 {
@@ -59,11 +60,11 @@ func (sr *Smiv1alpha2Router) Reconcile(canary *flaggerv1.Canary) error {
 		Backends: []smiv1alpha2.TrafficSplitBackend{
 			{
 				Service: canaryName,
-				Weight:  0,
+				Weight:  initialCanaryWeight,
 			},
 			{
 				Service: primaryName,
-				Weight:  100,
+				Weight:  initialPrimaryWeight,
 			},
 		},
 	}

--- a/pkg/router/smi_v1alpha2_test.go
+++ b/pkg/router/smi_v1alpha2_test.go
@@ -136,3 +136,62 @@ func TestSmiv1alpha2Router_GetRoutes(t *testing.T) {
 	assert.Equal(t, 0, c)
 	assert.False(t, m)
 }
+
+func TestSmiv1alpha2Router_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &Smiv1alpha2Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestSmiv1alpha2Router_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &Smiv1alpha2Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/smi_v1alpha3.go
+++ b/pkg/router/smi_v1alpha3.go
@@ -46,6 +46,7 @@ type Smiv1alpha3Router struct {
 // Reconcile creates or updates the SMI traffic split
 func (sr *Smiv1alpha3Router) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, primaryName, canaryName := canary.GetServiceNames()
+	initialPrimaryWeight, initialCanaryWeight := initializationWeights(canary)
 
 	var host string
 	if len(canary.Spec.Service.Hosts) > 0 {
@@ -59,11 +60,11 @@ func (sr *Smiv1alpha3Router) Reconcile(canary *flaggerv1.Canary) error {
 		Backends: []smiv1alpha3.TrafficSplitBackend{
 			{
 				Service: canaryName,
-				Weight:  0,
+				Weight:  initialCanaryWeight,
 			},
 			{
 				Service: primaryName,
-				Weight:  100,
+				Weight:  initialPrimaryWeight,
 			},
 		},
 	}

--- a/pkg/router/smi_v1alpha3_test.go
+++ b/pkg/router/smi_v1alpha3_test.go
@@ -136,3 +136,62 @@ func TestSmiv1alpha3Router_GetRoutes(t *testing.T) {
 	assert.Equal(t, 0, c)
 	assert.False(t, m)
 }
+
+func TestSmiv1alpha3Router_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &Smiv1alpha2Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestSmiv1alpha3Router_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &Smiv1alpha3Router{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		smiClient:     mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/traefik_test.go
+++ b/pkg/router/traefik_test.go
@@ -156,3 +156,58 @@ func TestTraefikRouter_GetRoutes(t *testing.T) {
 	assert.Equal(t, 0, c)
 	assert.False(t, m)
 }
+
+func TestTraefikRouter_ProgressiveInit(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &TraefikRouter{
+		traefikClient: mocks.meshClient,
+		logger:        mocks.logger,
+	}
+
+	canary := mocks.canary
+	canarySpec := &canary.Spec
+	canarySpec.ProgressiveInitialization = true
+	canarySpec.Analysis.StepWeightPromotion = canarySpec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to canary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 0, primaryWeight)
+	assert.Equal(t, 100, canaryWeight)
+}
+
+func TestTraefikRouter_ProgressiveUpdate(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &TraefikRouter{
+		traefikClient: mocks.meshClient,
+		logger:        mocks.logger,
+	}
+
+	canary := mocks.canary
+	canary.Spec.Analysis.StepWeightPromotion = canary.Spec.Analysis.StepWeight
+	err := router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// check virtual service routes all traffic to primary initially
+	primaryWeight, canaryWeight, _, err := router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+
+	// test progressive update
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	cdClone := cd.DeepCopy()
+	cdClone.Spec.ProgressiveInitialization = true
+	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), cdClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// apply
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	// verify virtual service traffic remains intact
+	primaryWeight, canaryWeight, _, err = router.GetRoutes(canary)
+	assert.Equal(t, 100, primaryWeight)
+	assert.Equal(t, 0, canaryWeight)
+}

--- a/pkg/router/util.go
+++ b/pkg/router/util.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	"strings"
 )
 
@@ -31,4 +32,17 @@ func filterMetadata(meta map[string]string) map[string]string {
 	// prevent Flux from overriding Flagger managed objects
 	meta[toolkitReconcileKey] = toolkitReconcileValue
 	return meta
+}
+
+// initializationWeights returns the initial weights that should be used to initialize
+// router resources depending on whether progressive initialization is enabled
+func initializationWeights(canary *flaggerv1.Canary) (
+	initialPrimaryWeight int,
+	initialCanaryWeight int,
+) {
+	if canary.ProgressiveInitialization() {
+		return 0, 100
+	} else {
+		return 100, 0
+	}
 }


### PR DESCRIPTION
Related to #635, this PR introduces a property to gradually move traffic from the canary to primary when initializing. Currently, the traffic is shifted 100% to primary as soon as the deployment is ready.

The new property works by setting the canary weight to 100 during router initialization, effectively keeping all the traffic on the existing workload. The initial status phase after initialization results in `Promoting`, which will also update the just created primary deployment to match canary. In the subsequent iteration of the `CanaryJob`, the traffic will start moving to the now ready primary deployment at the rate set by `spec.analysis.stepWeightPromotion`.