### PR TITLE
helm: Add namespace to namespaced resources in chart templates

### DIFF
--- a/charts/flagger/templates/account.yaml
+++ b/charts/flagger/templates/account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "flagger.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- if .Values.serviceAccount.annotations }}
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "flagger.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ template "flagger.chart" . }}
     app.kubernetes.io/name: {{ template "flagger.name" . }}

--- a/charts/flagger/templates/pdb.yaml
+++ b/charts/flagger/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "flagger.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   selector:

--- a/charts/flagger/templates/psp.yaml
+++ b/charts/flagger/templates/psp.yaml
@@ -50,6 +50,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "flagger.fullname" . }}-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ template "flagger.chart" . }}
     app.kubernetes.io/name: {{ template "flagger.name" . }}


### PR DESCRIPTION
This will add the namespace to namespaced resources in the flagger helm chart.

This was already done for some resources, e.g. the podmonitor or prometheus deployment, but was missing at other places.