### PR TITLE
feat: shift traffic to canary during kubernetes provider b/g

### DIFF
--- a/docs/gitbook/usage/deployment-strategies.md
+++ b/docs/gitbook/usage/deployment-strategies.md
@@ -18,7 +18,7 @@ a service mesh or an ingress controller. For Blue/Green deployments no service m
 
 A canary analysis is triggered by changes in any of the following objects:
 
-* Deployment PodSpec \(container image, command, ports, env, resources, etc\)
+* Spec \(container image, command, ports, env, resources, etc\) of referenced target \(Deployment, DaemonSet, StatefulSet\)
 * ConfigMaps mounted as volumes or mapped to environment variables
 * Secrets mounted as volumes or mapped to environment variables
 
@@ -328,7 +328,7 @@ Blue/Green rollout steps for service mesh:
 * run conformance tests for the canary pods
 * run load tests and metric checks for the canary pods every minute
 * abort the canary release if the failure threshold is reached
-* route traffic to canary (This doesn't happen when using the kubernetes provider)
+* route traffic to canary
 * promote canary spec over primary (blue)
 * wait for primary rollout
 * route traffic to primary

--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -95,7 +95,7 @@ func (c *Controller) revertMesh(r *flaggerv1.Canary) error {
 		provider = r.Spec.Provider
 	}
 
-	meshRouter := c.routerFactory.MeshRouter(provider, "")
+	meshRouter := c.routerFactory.MeshRouter(provider, "", "")
 	if err := meshRouter.Finalize(r); err != nil {
 		return fmt.Errorf("meshRouter.Finlize failed: %w", err)
 	}

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -75,7 +75,7 @@ func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labe
 }
 
 // MeshRouter returns a service mesh router
-func (factory *Factory) MeshRouter(provider string, labelSelector string) Interface {
+func (factory *Factory) MeshRouter(provider string, labelSelector string, labelValue string) Interface {
 	switch {
 	case strings.HasPrefix(provider, flaggerv1.AppMeshProvider+":v1beta2"):
 		return &AppMeshv1beta2Router{
@@ -214,7 +214,13 @@ func (factory *Factory) MeshRouter(provider string, labelSelector string) Interf
 			setOwnerRefs:     factory.setOwnerRefs,
 		}
 	case provider == flaggerv1.KubernetesProvider:
-		return &NopRouter{}
+		return &KubernetesDefaultRouter{
+			logger:        factory.logger,
+			flaggerClient: factory.flaggerClient,
+			kubeClient:    factory.kubeClient,
+			labelSelector: labelSelector,
+			labelValue:    labelValue,
+		}
 	default:
 		return &IstioRouter{
 			logger:        factory.logger,

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -202,6 +202,12 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 
 	// update existing service pod selector and ports
 	if svc != nil {
+		// if the apex service routes to the canary it does not get touched
+		apexName, _, _ := canary.GetServiceNames()
+		if name == apexName && svc.Spec.Selector[c.labelSelector] == fmt.Sprintf("%s-canary", c.labelValue) {
+			return nil
+		}
+
 		sortPorts := func(a, b interface{}) bool {
 			return a.(corev1.ServicePort).Port < b.(corev1.ServicePort).Port
 		}


### PR DESCRIPTION
## Current situation

Currently traffic is not routed to the canary once it is up and running if the kubernetes provider is used.
Instead once it's ready the primary receives a rolling update instead doing a real blue green switch.

## Proposal

The apex service could easily be routing traffic to the canary once the canary is up. Flagger would change the service label to the canary and change it back to the primary once the primary is rolled out.

## Background

I'm looking to replace a currently manually executed workflow for doing a b/g for with one service which involves manually rollout and changing the service between canary and primary on a cluster with no service mesh.

I reckon we could easily support a real b/g for the kubernetes provider. This pr uses the default kubernetes router for this and makes it compatible for the serviceMesh router. The router would now supports setting routes, where behind the scenes it only supports either all or nothing to the canary.  

**Note**: There are no tests yet added, if you consider this to be merged I will happily extend the pr 👍🏻 