### PR TITLE
helm: Added the option to supply additional volumes

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           secret:
             secretName: "{{ .Values.controlplane.kubeconfig.secretName }}"
         {{- end }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 -}}
+        {{- end }}
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
       {{- end }}                  

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -177,3 +177,8 @@ podDisruptionBudget:
 podLabels: {}
 
 noCrossNamespaceRefs: false
+
+#Placeholder to supply additional volumes to the flagger pod
+additionalVolumes: {}
+  # - name: tmpfs
+  #   emptyDir: {}


### PR DESCRIPTION
- This PR adds the option to supply additional volumes to the flagger pod.
- Use Case: In some implementations flagger has to be part of the mesh, sometimes some additional volumeMounts are needed on the sidecar container, thus a placeholder for specifying a volume for flagger pod. 
- This is a non-breaking change
