### PR TITLE
Let helm auto-detect appropriate API version for PDB

### DIFF
--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 1.29.0
+version: 1.29.1
 appVersion: 1.29.0
 kubeVersion: ">=1.19.0-0"
 engine: gotpl

--- a/charts/flagger/templates/_helpers.tpl
+++ b/charts/flagger/templates/_helpers.tpl
@@ -40,3 +40,29 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for policy.
+*/}}
+{{- define "capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/flagger/templates/pdb.yaml
+++ b/charts/flagger/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "flagger.name" . }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -177,3 +177,7 @@ podDisruptionBudget:
 podLabels: {}
 
 noCrossNamespaceRefs: false
+
+# Set to explicitly determine which API objects to deploy based on supported Kubernetes version
+# Leave blank to allow helm to auto-detect your cluster version
+kubeVersion:

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: loadtester
-version: 0.28.1
+version: 0.28.2
 appVersion: 0.28.1
 kubeVersion: ">=1.19.0-0"
 engine: gotpl

--- a/charts/loadtester/templates/_helpers.tpl
+++ b/charts/loadtester/templates/_helpers.tpl
@@ -30,3 +30,29 @@ Create chart name and version as used by the chart label.
 {{- define "loadtester.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for policy.
+*/}}
+{{- define "capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/loadtester/templates/pdb.yaml
+++ b/charts/loadtester/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loadtester.fullname" . }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -92,3 +92,7 @@ securityContext:
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
+
+# Set to explicitly determine which API objects to deploy based on supported Kubernetes version
+# Leave blank to allow helm to auto-detect your cluster version
+kubeVersion:


### PR DESCRIPTION
Hi guys,

I noticed today that with the latest flagger chart, I can't install to Kubernetes 1.25 with PDB enabled, since the `policy/v1beta` API is deprecated in 1.25.

`policy/v1` introduces no schema changes, so I've just adjusted the chart (*thanks to Bitnami's common template*) to autodetect the current version of Kubernetes, and allowing the user to manually override this if necessary.

This way, if there are users still using Kubernetes < 1.21 (*when `policy/v1` was introduced*), they'll be unaffected by this change.

I bumped the semver version, but I'm not sure how you prefer to manage releases, so happy to make changes if requested :)

Cheers!
D

