### PR TITLE
Disable Flux helm drift detection for managed resources

### DIFF
--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -393,7 +393,7 @@ func TestServiceRouter_InitializeMetadata(t *testing.T) {
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(primarySvc.Annotations))
+	assert.Equal(t, 2, len(primarySvc.Annotations))
 	assert.Equal(t, "podinfo-primary", primarySvc.Labels["app"])
 }
 
@@ -425,12 +425,12 @@ func TestServiceRouter_ReconcileMetadata(t *testing.T) {
 
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(canarySvc.Annotations))
+	assert.Equal(t, 2, len(canarySvc.Annotations))
 	assert.Equal(t, "podinfo-canary", canarySvc.Labels["app"])
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(primarySvc.Annotations))
+	assert.Equal(t, 2, len(primarySvc.Annotations))
 	assert.Equal(t, "podinfo-primary", primarySvc.Labels["app"])
 
 	mocks.canary.Spec.Service.Apex = &flaggerv1.CustomMetadata{

--- a/pkg/router/util.go
+++ b/pkg/router/util.go
@@ -7,6 +7,7 @@ import (
 const (
 	toolkitMarker         = "toolkit.fluxcd.io"
 	toolkitReconcileKey   = "kustomize.toolkit.fluxcd.io/reconcile"
+	helmDriftDetectionKey = "helm.toolkit.fluxcd.io/driftDetection"
 	toolkitReconcileValue = "disabled"
 )
 
@@ -30,5 +31,6 @@ func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []stri
 func filterMetadata(meta map[string]string) map[string]string {
 	// prevent Flux from overriding Flagger managed objects
 	meta[toolkitReconcileKey] = toolkitReconcileValue
+	meta[helmDriftDetectionKey] = toolkitReconcileValue
 	return meta
 }

--- a/test/kubernetes/test-deployment.sh
+++ b/test/kubernetes/test-deployment.sh
@@ -93,6 +93,13 @@ if [ -z "$passed" ]; then
   kubectl -n test get svc/podinfo-svc -oyaml
   exit 1
 fi
+passed=$(kubectl -n test get svc/podinfo-svc -oyaml 2>&1 | { grep 'helm.toolkit.fluxcd.io/driftDetection' || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 helm drift detection annotation test failed'
+  kubectl -n test get svc/podinfo-svc -oyaml
+  exit 1
+fi
+
 passed=$(kubectl -n test get deploy/podinfo-primary -oyaml 2>&1 | { grep test-label-prefix || true; })
 if [ -z "$passed" ]; then
   echo -e '\u2716 primary copy labels by prefix test failed'


### PR DESCRIPTION
Disable helm-controller drift detection for managed resources by adding the `helm.toolkit.fluxcd.io/driftDetection: disabled` annotation to the resource. (ref: https://fluxcd.io/flux/components/helm/helmreleases/#excluding-resources-from-drift-detection)

Fixes #1407 