### PR TITLE
Helm: Allow configuring deployment `annotations`

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.leaderElection.replicaCount }}
   {{- if eq .Values.leaderElection.enabled false }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -1,5 +1,8 @@
 # Default values for flagger.
 
+## Deployment annotations
+# annotations: {}
+
 image:
   repository: ghcr.io/fluxcd/flagger
   tag: 1.29.0


### PR DESCRIPTION
Currently this is not possible to do.

Follows the standard pattern (used by e.g. grafana ([1](https://github.com/grafana/helm-charts/blob/7a3d38cc324609351d73d62fcc3aa9fd41cce829/charts/grafana/templates/deployment.yaml#L12-L15),[2](https://github.com/grafana/helm-charts/blob/7a3d38cc324609351d73d62fcc3aa9fd41cce829/charts/grafana/values.yaml#L164-L165))), which should fit in here given we already have `podAnnotations`.