### PR TITLE
Resume target scaler during finalization

### DIFF
--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -437,14 +437,15 @@ type LocalObjectReference struct {
 
 type AutoscalerRefernce struct {
 	// API version of the scaler
-	// +optional
+	// +required
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the scaler
-	// +optional
+	// +required
 	Kind string `json:"kind,omitempty"`
 
 	// Name of the scaler
+	// +required
 	Name string `json:"name"`
 
 	// PrimaryScalerQueries maps a unique id to a query for the primary


### PR DESCRIPTION
Resume target scaler during finalization so that targetRef deployment does not get stuck at 0 replicas after canary has been deleted.

Fixes #1422 