### PR TITLE
Add `spec.suspend` to allow suspending canary

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -27,6 +27,10 @@ spec:
         - name: Weight
           type: string
           jsonPath: .status.canaryWeight
+        - name: Suspended
+          type: boolean
+          jsonPath: .spec.suspend
+          priority: 1
         - name: FailedChecks
           type: string
           jsonPath: .status.failedChecks
@@ -849,6 +853,9 @@ spec:
                   type: boolean
                 revertOnDeletion:
                   description: Revert mutated resources to original spec on deletion
+                  type: boolean
+                suspend:
+                  description: Suspend Canary disabling/pausing all canary runs
                   type: boolean
                 analysis:
                   description: Canary analysis for this canary

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -27,6 +27,10 @@ spec:
         - name: Weight
           type: string
           jsonPath: .status.canaryWeight
+        - name: Suspended
+          type: boolean
+          jsonPath: .spec.suspend
+          priority: 1
         - name: FailedChecks
           type: string
           jsonPath: .status.failedChecks
@@ -849,6 +853,9 @@ spec:
                   type: boolean
                 revertOnDeletion:
                   description: Revert mutated resources to original spec on deletion
+                  type: boolean
+                suspend:
+                  description: Suspend Canary disabling/pausing all canary runs
                   type: boolean
                 analysis:
                   description: Canary analysis for this canary

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -379,3 +379,10 @@ On each run, Flagger calls the webhooks, checks the metrics and if the failed ch
 stops the analysis and rolls back the canary.
 If alerting is configured, Flagger will post the analysis result using the alert providers.
 
+## Canary suspend
+
+The `suspend` field can be set to true to suspend the Canary. If a Canary is suspended,
+its reconciliation is completely paused. This means that changes to target workloads,
+tracked ConfigMaps and Secrets don't trigger a Canary run and changes to resources generated
+by Flagger are not corrected. If the Canary was suspended during an active Canary run,
+then the run is paused without disturbing the workloads or the traffic weights.

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -27,6 +27,10 @@ spec:
         - name: Weight
           type: string
           jsonPath: .status.canaryWeight
+        - name: Suspended
+          type: boolean
+          jsonPath: .spec.suspend
+          priority: 1
         - name: FailedChecks
           type: string
           jsonPath: .status.failedChecks
@@ -849,6 +853,9 @@ spec:
                   type: boolean
                 revertOnDeletion:
                   description: Revert mutated resources to original spec on deletion
+                  type: boolean
+                suspend:
+                  description: Suspend Canary disabling/pausing all canary runs
                   type: boolean
                 analysis:
                   description: Canary analysis for this canary

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -110,6 +110,12 @@ type CanarySpec struct {
 	// revert canary mutation on deletion of canary resource
 	// +optional
 	RevertOnDeletion bool `json:"revertOnDeletion,omitempty"`
+
+	// Suspend, if set to true will suspend the Canary, disabling any canary runs
+	// regardless of any changes to its target, services, etc. Note that if the
+	// Canary is suspended during an analysis, its paused until the Canary is unsuspended.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // CanaryService defines how ClusterIP services, service mesh or ingress routing objects are generated

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -164,6 +164,14 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 		return
 	}
 
+	if cd.Spec.Suspend {
+		msg := "skipping canary run as object is suspended"
+		c.logger.With("canary", fmt.Sprintf("%s.%s", name, namespace)).
+			Debug(msg)
+		c.recordEventInfof(cd, msg)
+		return
+	}
+
 	// override the global provider if one is specified in the canary spec
 	provider := c.meshProvider
 	if cd.Spec.Provider != "" {
@@ -172,6 +180,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 	// init controller based on target kind
 	canaryController := c.canaryFactory.Controller(cd.Spec.TargetRef.Kind)
+
 	labelSelector, labelValue, ports, err := canaryController.GetMetadata(cd)
 	if err != nil {
 		c.recordEventWarningf(cd, "%v", err)


### PR DESCRIPTION
`spec.suspend`, if set to true will suspend the Canary, disabling any canary runs regardless of any changes to its target, services, etc. Note that if the Canary is suspended during an analysis, its paused until the Canary is unsuspended.