### PR TITLE
Fix panic when annotation of ingress is empty

### DIFF
--- a/pkg/router/util.go
+++ b/pkg/router/util.go
@@ -29,6 +29,9 @@ func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []stri
 }
 
 func filterMetadata(meta map[string]string) map[string]string {
+	if meta == nil {
+		meta = map[string]string{}
+	}
 	// prevent Flux from overriding Flagger managed objects
 	meta[toolkitReconcileKey] = toolkitReconcileValue
 	meta[helmDriftDetectionKey] = toolkitReconcileValue


### PR DESCRIPTION
When the annotation of ingress is not set, the returned value is nil (not empty map). Trying to assign to this map leads to panic.

Closes #1277 