### PR TITLE
Add support to istio LEAST_REQUEST destination rule load balancib

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -751,6 +751,7 @@ spec:
                                 - LEAST_CONN
                                 - RANDOM
                                 - PASSTHROUGH
+                                - LEAST_REQUEST
                               type: string
                         outlierDetection:
                           description: Settings controlling eviction of unhealthy hosts from the load balancing pool.

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -751,6 +751,7 @@ spec:
                                 - LEAST_CONN
                                 - RANDOM
                                 - PASSTHROUGH
+                                - LEAST_REQUEST
                               type: string
                         outlierDetection:
                           description: Settings controlling eviction of unhealthy hosts from the load balancing pool.

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -751,6 +751,7 @@ spec:
                                 - LEAST_CONN
                                 - RANDOM
                                 - PASSTHROUGH
+                                - LEAST_REQUEST
                               type: string
                         outlierDetection:
                           description: Settings controlling eviction of unhealthy hosts from the load balancing pool.

--- a/pkg/apis/istio/v1alpha3/destination_rule.go
+++ b/pkg/apis/istio/v1alpha3/destination_rule.go
@@ -419,6 +419,12 @@ const (
 	// advanced use cases. Refer to Original Destination load balancer in
 	// Envoy for further details.
 	SimpleLBPassthrough SimpleLB = "PASSTHROUGH"
+
+	// The least request load balancer spreads load across endpoints, 
+	// favoring endpoints with the least outstanding requests. This is generally 
+	// safer and outperforms ROUND_ROBIN in nearly all cases. Prefer to use LEAST_REQUEST 
+	// as a drop-in replacement for ROUND_ROBIN.
+	SimpleLBLeastRequest SimpleLB = "LEAST_REQUEST"
 )
 
 // Consistent Hash-based load balancing can be used to provide soft


### PR DESCRIPTION
Istio will deprecate LEAST_CONN option of destination rule load balancing algorithms and LEAST_REQUEST type is being used instead of LEAST_CONN.

[istio code](https://github.com/istio/api/blob/master/networking/v1beta1/destination_rule.proto#L476)

