### PR TITLE
Fix Traefik request-duration metric

### DIFF
--- a/pkg/metrics/observers/traefik.go
+++ b/pkg/metrics/observers/traefik.go
@@ -54,7 +54,7 @@ var traefikQueries = map[string]string{
 				}[{{ interval }}]
 			)
 		) by (le)
-	)`,
+	) * 1000`,
 }
 
 type TraefikObserver struct {

--- a/pkg/metrics/observers/traefik_test.go
+++ b/pkg/metrics/observers/traefik_test.go
@@ -85,7 +85,7 @@ func TestTraefikObserver_GetRequestSuccessRate(t *testing.T) {
 }
 
 func TestTraefikObserver_GetRequestDuration(t *testing.T) {
-	expected := ` histogram_quantile( 0.99, sum( rate( traefik_service_request_duration_seconds_bucket{ service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd" }[1m] ) ) by (le) )`
+	expected := ` histogram_quantile( 0.99, sum( rate( traefik_service_request_duration_seconds_bucket{ service=~"default-podinfo-canary-[0-9a-zA-Z-]+@kubernetescrd" }[1m] ) ) by (le) ) * 1000`
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		promql := r.URL.Query()["query"][0]

--- a/test/traefik/install.sh
+++ b/test/traefik/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-TRAEFIK_CHART_VERSION="10.20.1" # traefik 2.7.0
+TRAEFIK_CHART_VERSION="24.0.0" # traefik 2.10.4
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin


### PR DESCRIPTION
The `request-duration` metric for Traefik returns the results in seconds, however the code assumes it is in milliseconds.

This PR fixes that.