### PR TITLE
Fix initial deployment downtime

### DIFF
--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -91,8 +91,7 @@ func (c *DaemonSetController) ScaleFromZero(cd *flaggerv1.Canary) error {
 	return nil
 }
 
-// Initialize creates the primary DaemonSet, scales down the canary DaemonSet,
-// and returns the pod selector label and container ports
+// Initialize creates the primary DaemonSet if it does not exist.
 func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary) (err error) {
 	err = c.createPrimaryDaemonSet(cd, c.includeLabelPrefix)
 	if err != nil {
@@ -105,13 +104,8 @@ func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary) (err error) {
 				return fmt.Errorf("%w", err)
 			}
 		}
-
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
-			Infof("Scaling down DaemonSet %s.%s", cd.Spec.TargetRef.Name, cd.Namespace)
-		if err := c.ScaleToZero(cd); err != nil {
-			return fmt.Errorf("ScaleToZero failed: %w", err)
-		}
 	}
+
 	return nil
 }
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -45,8 +45,7 @@ type DeploymentController struct {
 	includeLabelPrefix []string
 }
 
-// Initialize creates the primary deployment, hpa,
-// scales to zero the canary deployment and returns the pod selector label and container ports
+// Initialize creates the primary deployment if it does not exist.
 func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 	if err := c.createPrimaryDeployment(cd, c.includeLabelPrefix); err != nil {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
@@ -57,12 +56,6 @@ func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 			if err := c.IsPrimaryReady(cd); err != nil {
 				return fmt.Errorf("%w", err)
 			}
-		}
-
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
-			Infof("Scaling down Deployment %s.%s", cd.Spec.TargetRef.Name, cd.Namespace)
-		if err := c.ScaleToZero(cd); err != nil {
-			return fmt.Errorf("scaling down canary deployment %s.%s failed: %w", cd.Spec.TargetRef.Name, cd.Namespace, err)
 		}
 	}
 

--- a/pkg/controller/scheduler_daemonset_test.go
+++ b/pkg/controller/scheduler_daemonset_test.go
@@ -46,9 +46,14 @@ func TestScheduler_DaemonSetNewRevision(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
 	mocks.ctrl.advanceCanary("podinfo", "default")
 
+	// check if ScaleToZero was performed
+	ds, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, ds.Spec.Template.Spec.NodeSelector, "flagger.app/scale-to-zero")
+
 	// update
 	dae2 := newDaemonSetTestDaemonSetV2()
-	_, err := mocks.kubeClient.AppsV1().DaemonSets("default").Update(context.TODO(), dae2, metav1.UpdateOptions{})
+	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Update(context.TODO(), dae2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// detect changes

--- a/pkg/controller/scheduler_deployment_test.go
+++ b/pkg/controller/scheduler_deployment_test.go
@@ -54,9 +54,14 @@ func TestScheduler_DeploymentNewRevision(t *testing.T) {
 	// initialization done
 	mocks.ctrl.advanceCanary("podinfo", "default")
 
+	// check if ScaleToZero was performed
+	dp, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), *dp.Spec.Replicas)
+
 	// update
 	dep2 := newDeploymentTestDeploymentV2()
-	_, err := mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
+	_, err = mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// detect changes


### PR DESCRIPTION
Fixes https://github.com/fluxcd/flagger/issues/1444.

After taking a look at the code, I think the current implementation could cause some issues: considering that if might be a bit of latency between scaling de `Deployment`/`DaemonSet` to 0 and updating the `Service`, the `Service` would be left with no `Pod`s to communicate to for a bit. This would be even worse if, for some reason, updating the `Service` failed, leaving the apex service with no `Pod`s for even longer.

This solution moves the `ScaleToZero` to be performed only after the apex service is already pointing to the `primary` target, and should therefore mitigate the issues described above.