### PR TITLE
Add gatewayRef port to Canary CRD

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -561,6 +561,11 @@ spec:
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
+                          port:
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                     corsPolicy:
                       description: Istio Cross-Origin Resource Sharing policy (CORS)
                       type: object

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -561,6 +561,11 @@ spec:
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
+                          port:
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                     corsPolicy:
                       description: Istio Cross-Origin Resource Sharing policy (CORS)
                       type: object

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -561,6 +561,11 @@ spec:
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
+                          port:
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                     corsPolicy:
                       description: Istio Cross-Origin Resource Sharing policy (CORS)
                       type: object


### PR DESCRIPTION
The Gateway API allows port to be specified as part of the ParentReference of an HttpRoute: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.ParentReference

Correspondingly, we should be able to specify a port as part of the gatewayRef in a Canary resource.

This field is already copied over to the parentRef of the HttpRoute resource managed by Flagger, all that is required is to add this field to the Canary CRD so that it can be set on Canary resources.