### PR TITLE
Fixing namespace of HelmRepository in installation docs

### DIFF
--- a/docs/gitbook/install/flagger-install-with-flux.md
+++ b/docs/gitbook/install/flagger-install-with-flux.md
@@ -42,7 +42,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: flagger
-  namespace: flux-system
+  namespace: flagger-system
 spec:
   interval: 1h
   url: oci://ghcr.io/fluxcd/charts


### PR DESCRIPTION
The documentation has the following config. The namespace of the HelmRepo is located in the flux-system and `HelmRelease.spec.chart.sourceRef.Namespace` is not configured

```
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: HelmRepository
metadata:
  name: flagger
  namespace: flux-system
spec:
  interval: 1h
  url: oci://ghcr.io/fluxcd/charts
  type: oci
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: flagger
  namespace: flagger-system
spec:
  interval: 1h
  releaseName: flagger
  install: # override existing Flagger CRDs
    crds: CreateReplace
  upgrade: # update Flagger CRDs
    crds: CreateReplace
  chart:
    spec:
      chart: flagger
      version: 1.x # update Flagger to the latest minor version
      interval: 1m # scan for new versions every six hours
      sourceRef:
        kind: HelmRepository
        name: flagger
      verify: # verify the chart signature with Cosign keyless
        provider: cosign 
  values:
    nodeSelector:
      kubernetes.io/os: linux
```