### PR TITLE
Avoid running traffic increase hooks when waiting for promotion or promoting

### DIFF
--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -456,7 +456,10 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 	// strategy: Canary progressive traffic increase
 	if c.nextStepWeight(cd, canaryWeight) > 0 {
 		// run hook only if traffic is not mirrored
-		if !mirrored {
+		if !mirrored &&
+			(cd.Status.Phase != flaggerv1.CanaryPhasePromoting &&
+				cd.Status.Phase != flaggerv1.CanaryPhaseWaitingPromotion &&
+				cd.Status.Phase != flaggerv1.CanaryPhaseFinalising) {
 			if promote := c.runConfirmTrafficIncreaseHooks(cd); !promote {
 				return
 			}


### PR DESCRIPTION
This is a fix for issue https://github.com/fluxcd/flagger/issues/1468.  This will stop traffic increase checks once the canary has moved into promotion statuses.

The only callout that I do have here would be if both hooks are configured on the max step weight, you will have to approve the traffic increase then the following iteration will involve the confirm promotion hook.  This can seem a bit redundant but it does satisfy the issue of continuous traffic increase hooks being called