### PR TITLE
e2e: Update Istio to v1.18 

### DIFF
--- a/docs/gitbook/tutorials/istio-ab-testing.md
+++ b/docs/gitbook/tutorials/istio-ab-testing.md
@@ -15,7 +15,7 @@ Install Istio with telemetry support and Prometheus:
 ```bash
 istioctl manifest install --set profile=default
 
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.8/samples/addons/prometheus.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.18/samples/addons/prometheus.yaml
 ```
 
 Install Flagger in the `istio-system` namespace:

--- a/docs/gitbook/tutorials/istio-progressive-delivery.md
+++ b/docs/gitbook/tutorials/istio-progressive-delivery.md
@@ -14,7 +14,7 @@ Install Istio with telemetry support and Prometheus:
 istioctl manifest install --set profile=default
 
 # Suggestion: Please change release-1.8 in below command, to your real istio version.
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.8/samples/addons/prometheus.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.18/samples/addons/prometheus.yaml
 ```
 
 Install Flagger in the `istio-system` namespace:

--- a/test/istio/install.sh
+++ b/test/istio/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.14.0"
+ISTIO_VER="1.18.2"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin
@@ -16,7 +16,7 @@ ${REPO_ROOT}/bin/istio-${ISTIO_VER}/bin/istioctl manifest install --set profile=
   --set values.pilot.resources.requests.cpu=100m \
   --set values.pilot.resources.requests.memory=100Mi
 
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.8/samples/addons/prometheus.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.18/samples/addons/prometheus.yaml
 kubectl -n istio-system rollout status deployment/prometheus
 
 kubectl -n istio-system get all


### PR DESCRIPTION
Upgrade istio version to latest 1.18.2 for testing and documents

Tested:
- e2e test with provider istio
- make test