### PR TITLE
ci: Generate SLSA provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
 
 jobs:
   release-flagger:
+    outputs:
+      hashes: ${{ steps.slsa.outputs.hashes }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed to write releases
@@ -112,6 +114,7 @@ jobs:
           cosign sign --yes ${{ digest_url }}
       - uses: anchore/sbom-action/download-syft@v0
       - name: Create release and SBOM
+        id: run-goreleaser
         uses: goreleaser/goreleaser-action@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
@@ -119,3 +122,26 @@ jobs:
           args: release --release-notes=notes.md --rm-dist --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate SLSA metadata
+        id: slsa
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          
+          hashes=$(echo -E $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+          echo "hashes=$hashes" >> $GITHUB_OUTPUT
+
+  release-provenance:
+    needs: [release-flagger]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      contents: write # for uploading attestations to GitHub releases.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      provenance-name: "provenance.intoto.jsonl"
+      base64-subjects: "${{ needs.release-flagger.outputs.hashes }}"
+      upload-assets: true


### PR DESCRIPTION
Generate SLSA provenance for Flagger (binaries, SBOM, source code) and publish the `provenance.intoto.jsonl` file to GH releases.