### PR TITLE
Avoid running traffic increase hooks after the last increase step has already been completed (and analyzed)

### DIFF
--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -465,15 +465,6 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 	// strategy: Canary progressive traffic increase
 	if c.nextStepWeight(cd, canaryWeight) > 0 {
-		// run hook only if traffic is not mirrored
-		if !mirrored &&
-			(cd.Status.Phase != flaggerv1.CanaryPhasePromoting &&
-				cd.Status.Phase != flaggerv1.CanaryPhaseWaitingPromotion &&
-				cd.Status.Phase != flaggerv1.CanaryPhaseFinalising) {
-			if promote := c.runConfirmTrafficIncreaseHooks(cd); !promote {
-				return
-			}
-		}
 		c.runCanary(cd, canaryController, meshRouter, mirrored, canaryWeight, primaryWeight, maxWeight)
 	}
 
@@ -542,6 +533,16 @@ func (c *Controller) runCanary(canary *flaggerv1.Canary, canaryController canary
 
 	// increase traffic weight
 	if canaryWeight < maxWeight {
+		// check trafic increace hook, only if traffic is not mirrored
+		if !mirrored &&
+			(cd.Status.Phase != flaggerv1.CanaryPhasePromoting &&
+				cd.Status.Phase != flaggerv1.CanaryPhaseWaitingPromotion &&
+				cd.Status.Phase != flaggerv1.CanaryPhaseFinalising) {
+			if promote := c.runConfirmTrafficIncreaseHooks(cd); !promote {
+				return
+			}
+		}
+
 		// If in "mirror" mode, do one step of mirroring before shifting traffic to canary.
 		// When mirroring, all requests go to primary and canary, but only responses from
 		// primary go back to the user.


### PR DESCRIPTION
This PR is an improvement on the PR https://github.com/fluxcd/flagger/pull/1470 which was released in version v1.33.0.

The goal is for the traffic increase webhook to only run when the next step is actually a traffic increase.

Without this change, Flagger will still be calling the traffic increase webhook even after the last increase step has already been analyzed, right before the verification promotion webhook.


The code logic can be compared with the promotion webhook call (already on the code):
https://github.com/fluxcd/flagger/blob/dfc0c96824b006d3592377f528878885ed46f6f6/pkg/controller/scheduler.go#L591-L595
