### PR TITLE
gatewayapi: add support for session affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/appmesh-abtest.yaml
+++ b/artifacts/examples/appmesh-abtest.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/appmesh-canary.yaml
+++ b/artifacts/examples/appmesh-canary.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/istio-abtest.yaml
+++ b/artifacts/examples/istio-abtest.yaml
@@ -10,7 +10,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/istio-canary.yaml
+++ b/artifacts/examples/istio-canary.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/linkerd-canary-steps.yaml
+++ b/artifacts/examples/linkerd-canary-steps.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/artifacts/examples/linkerd-canary.yaml
+++ b/artifacts/examples/linkerd-canary.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/charts/podinfo/templates/canary.yaml
+++ b/charts/podinfo/templates/canary.yaml
@@ -14,7 +14,7 @@ spec:
     kind: Deployment
     name:  {{ template "podinfo.fullname" . }}
   autoscalerRef:
-    apiVersion: autoscaling/v2beta1
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name:  {{ template "podinfo.fullname" . }}
   service:

--- a/charts/podinfo/templates/hpa.yaml
+++ b/charts/podinfo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "podinfo.fullname" . }}

--- a/docs/gitbook/tutorials/appmesh-progressive-delivery.md
+++ b/docs/gitbook/tutorials/appmesh-progressive-delivery.md
@@ -80,7 +80,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -76,7 +76,7 @@ spec:
     name: podinfo
   # HPA reference
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
+++ b/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
@@ -156,7 +156,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:
@@ -409,7 +409,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:
@@ -518,7 +518,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/gloo-progressive-delivery.md
+++ b/docs/gitbook/tutorials/gloo-progressive-delivery.md
@@ -110,7 +110,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/istio-ab-testing.md
+++ b/docs/gitbook/tutorials/istio-ab-testing.md
@@ -84,7 +84,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/istio-progressive-delivery.md
+++ b/docs/gitbook/tutorials/istio-progressive-delivery.md
@@ -85,7 +85,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:
@@ -316,7 +316,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/kubernetes-blue-green.md
+++ b/docs/gitbook/tutorials/kubernetes-blue-green.md
@@ -84,7 +84,7 @@ spec:
   progressDeadlineSeconds: 60
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/linkerd-progressive-delivery.md
+++ b/docs/gitbook/tutorials/linkerd-progressive-delivery.md
@@ -98,7 +98,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   # the maximum time in seconds for the canary deployment
@@ -426,7 +426,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   service:

--- a/docs/gitbook/tutorials/nginx-progressive-delivery.md
+++ b/docs/gitbook/tutorials/nginx-progressive-delivery.md
@@ -110,7 +110,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   # the maximum time in seconds for the canary deployment

--- a/docs/gitbook/tutorials/osm-progressive-delivery.md
+++ b/docs/gitbook/tutorials/osm-progressive-delivery.md
@@ -86,7 +86,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   # the maximum time in seconds for the canary deployment

--- a/docs/gitbook/tutorials/skipper-progressive-delivery.md
+++ b/docs/gitbook/tutorials/skipper-progressive-delivery.md
@@ -113,7 +113,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   # the maximum time in seconds for the canary deployment

--- a/docs/gitbook/tutorials/traefik-progressive-delivery.md
+++ b/docs/gitbook/tutorials/traefik-progressive-delivery.md
@@ -103,7 +103,7 @@ spec:
     name: podinfo
   # HPA reference (optional)
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
   # the maximum time in seconds for the canary deployment

--- a/docs/gitbook/tutorials/zero-downtime-deployments.md
+++ b/docs/gitbook/tutorials/zero-downtime-deployments.md
@@ -139,7 +139,7 @@ Note that without resource requests the horizontal pod autoscaler can't determin
 A production environment should be able to handle traffic bursts without impacting the quality of service. This can be achieved with Kubernetes autoscaling capabilities. Autoscaling in Kubernetes has two dimensions: the Cluster Autoscaler that deals with node scaling operations and the Horizontal Pod Autoscaler that automatically scales the number of pods in a deployment.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 spec:
   scaleTargetRef:

--- a/docs/gitbook/usage/deployment-strategies.md
+++ b/docs/gitbook/usage/deployment-strategies.md
@@ -11,7 +11,7 @@ Flagger can run automated application analysis, promotion and rollback for the f
 * **Blue/Green Mirroring** \(traffic shadowing\)
   * Istio
 * **Canary Release with Session Affinity** \(progressive traffic shifting combined with cookie based routing\)
-  * Istio
+  * Istio, Gateway API
 
 For Canary releases and A/B testing you'll need a Layer 7 traffic management solution like
 a service mesh or an ingress controller. For Blue/Green deployments no service mesh or ingress controller is required.
@@ -408,7 +408,7 @@ cookie based routing with regular weight based routing. This means once a user i
 version of our application (based on the traffic weights), they're always routed to that version, i.e.
 they're never routed back to the old version of our application.
 
-You can enable this, by specifying `.spec.analsyis.sessionAffinity` in the Canary (only Istio is supported):
+You can enable this, by specifying `.spec.analsyis.sessionAffinity` in the Canary:
 
 ```yaml
   analysis:

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -65,7 +65,7 @@ spec:
     kind: Deployment
     name: podinfo
   autoscalerRef:
-    apiVersion: autoscaling/v2beta2
+    apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     name: podinfo
     primaryScalerReplicas:

--- a/pkg/router/gateway_api_v1beta1_test.go
+++ b/pkg/router/gateway_api_v1beta1_test.go
@@ -18,8 +18,13 @@ package router
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+	"github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,12 +66,248 @@ func TestGatewayAPIV1Beta1Router_Routes(t *testing.T) {
 	err := router.Reconcile(canary)
 	require.NoError(t, err)
 
-	err = router.SetRoutes(canary, 50, 50, false)
-	require.NoError(t, err)
+	t.Run("normal", func(t *testing.T) {
+		err = router.SetRoutes(canary, 50, 50, false)
+		require.NoError(t, err)
 
-	httpRoute, err := router.gatewayAPIClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
-	require.NoError(t, err)
+		httpRoute, err := router.gatewayAPIClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
 
-	primary := httpRoute.Spec.Rules[0].BackendRefs[0]
-	assert.Equal(t, int32(50), *primary.Weight)
+		primary := httpRoute.Spec.Rules[0].BackendRefs[0]
+		assert.Equal(t, int32(50), *primary.Weight)
+	})
+
+	t.Run("session affinity", func(t *testing.T) {
+		canary := mocks.canary.DeepCopy()
+		cookieKey := "flagger-cookie"
+		// enable session affinity and start canary run
+		canary.Spec.Analysis.SessionAffinity = &flaggerv1.SessionAffinity{
+			CookieName: cookieKey,
+			MaxAge:     300,
+		}
+		_, pSvcName, cSvcName := canary.GetServiceNames()
+
+		err := router.SetRoutes(canary, 90, 10, false)
+
+		hr, err := mocks.meshClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, hr.Spec.Rules, 2)
+
+		stickyRule := hr.Spec.Rules[0]
+		weightedRule := hr.Spec.Rules[1]
+
+		// stickyRoute should match against a cookie and direct all traffic to the canary when a canary run is active.
+		cookieMatch := stickyRule.Matches[0].Headers[0]
+		assert.Equal(t, *cookieMatch.Type, v1beta1.HeaderMatchRegularExpression)
+		assert.Equal(t, string(cookieMatch.Name), cookieHeader)
+		assert.Contains(t, cookieMatch.Value, cookieKey)
+
+		assert.Equal(t, len(stickyRule.BackendRefs), 2)
+		for _, backendRef := range stickyRule.BackendRefs {
+			if string(backendRef.BackendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(0))
+			}
+			if string(backendRef.BackendRef.Name) == cSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(100))
+			}
+		}
+
+		// weightedRoute should do regular weight based routing and inject the Set-Cookie header
+		// for all responses returned from the canary deployment.
+		var found bool
+		for _, backendRef := range weightedRule.BackendRefs {
+			if string(backendRef.Name) == cSvcName {
+				found = true
+				filter := backendRef.Filters[0]
+				assert.Equal(t, filter.Type, v1beta1.HTTPRouteFilterResponseHeaderModifier)
+				assert.NotNil(t, filter.ResponseHeaderModifier)
+				assert.Equal(t, string(filter.ResponseHeaderModifier.Add[0].Name), setCookieHeader)
+				assert.Equal(t, filter.ResponseHeaderModifier.Add[0].Value, fmt.Sprintf("%s; %s=%d", canary.Status.SessionAffinityCookie, maxAgeAttr, 300))
+				assert.Equal(t, *backendRef.Weight, int32(10))
+			}
+			if string(backendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.Weight, int32(90))
+			}
+		}
+		assert.True(t, found)
+		assert.True(t, strings.HasPrefix(canary.Status.SessionAffinityCookie, cookieKey))
+
+		// reconcile Canary and HTTPRoute
+		err = router.Reconcile(canary)
+		require.NoError(t, err)
+
+		// HTTPRoute should be unchanged
+		hr, err = mocks.meshClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, hr.Spec.Rules, 2)
+		assert.Empty(t, cmp.Diff(hr.Spec.Rules[0], stickyRule))
+		assert.Empty(t, cmp.Diff(hr.Spec.Rules[1], weightedRule))
+
+		// further continue the canary run
+		err = router.SetRoutes(canary, 50, 50, false)
+		require.NoError(t, err)
+		hr, err = mocks.meshClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		stickyRule = hr.Spec.Rules[0]
+		weightedRule = hr.Spec.Rules[1]
+
+		// stickyRoute should match against a cookie and direct all traffic to the canary when a canary run is active.
+		cookieMatch = stickyRule.Matches[0].Headers[0]
+		assert.Equal(t, *cookieMatch.Type, v1beta1.HeaderMatchRegularExpression)
+		assert.Equal(t, string(cookieMatch.Name), cookieHeader)
+		assert.Contains(t, cookieMatch.Value, cookieKey)
+
+		assert.Equal(t, len(stickyRule.BackendRefs), 2)
+		for _, backendRef := range stickyRule.BackendRefs {
+			if string(backendRef.BackendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(0))
+			}
+			if string(backendRef.BackendRef.Name) == cSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(100))
+			}
+		}
+
+		// weightedRoute should do regular weight based routing and inject the Set-Cookie header
+		// for all responses returned from the canary deployment.
+		found = false
+		for _, backendRef := range weightedRule.BackendRefs {
+			if string(backendRef.Name) == cSvcName {
+				found = true
+				filter := backendRef.Filters[0]
+				assert.Equal(t, filter.Type, v1beta1.HTTPRouteFilterResponseHeaderModifier)
+				assert.NotNil(t, filter.ResponseHeaderModifier)
+				assert.Equal(t, string(filter.ResponseHeaderModifier.Add[0].Name), setCookieHeader)
+				assert.Equal(t, filter.ResponseHeaderModifier.Add[0].Value, fmt.Sprintf("%s; %s=%d", canary.Status.SessionAffinityCookie, maxAgeAttr, 300))
+
+				assert.Equal(t, *backendRef.Weight, int32(50))
+			}
+			if string(backendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.Weight, int32(50))
+			}
+		}
+		assert.True(t, found)
+
+		// promotion
+		err = router.SetRoutes(canary, 100, 0, false)
+		require.NoError(t, err)
+		hr, err = mocks.meshClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Empty(t, canary.Status.SessionAffinityCookie)
+		assert.Contains(t, canary.Status.PreviousSessionAffinityCookie, cookieKey)
+
+		stickyRule = hr.Spec.Rules[0]
+		weightedRule = hr.Spec.Rules[1]
+
+		// Assert that the stucky rule matches against the previous cookie and tells clients to delete it.
+		cookieMatch = stickyRule.Matches[0].Headers[0]
+		assert.Equal(t, *cookieMatch.Type, v1beta1.HeaderMatchRegularExpression)
+		assert.Equal(t, string(cookieMatch.Name), cookieHeader)
+		assert.Contains(t, cookieMatch.Value, cookieKey)
+
+		assert.Equal(t, stickyRule.Filters[0].Type, v1beta1.HTTPRouteFilterResponseHeaderModifier)
+		headerModifier := stickyRule.Filters[0].ResponseHeaderModifier
+		assert.NotNil(t, headerModifier)
+		assert.Equal(t, string(headerModifier.Add[0].Name), setCookieHeader)
+		assert.Equal(t, headerModifier.Add[0].Value, fmt.Sprintf("%s; %s=%d", canary.Status.PreviousSessionAffinityCookie, maxAgeAttr, -1))
+
+		for _, backendRef := range stickyRule.BackendRefs {
+			if string(backendRef.BackendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(100))
+			}
+			if string(backendRef.BackendRef.Name) == cSvcName {
+				assert.Equal(t, *backendRef.BackendRef.Weight, int32(0))
+			}
+		}
+
+		for _, backendRef := range weightedRule.BackendRefs {
+			if string(backendRef.Name) == cSvcName {
+				// Assert the weighted rule does not send Set-Cookie headers anymore
+				assert.Len(t, backendRef.Filters, 0)
+				assert.Equal(t, *backendRef.Weight, int32(0))
+			}
+			if string(backendRef.Name) == pSvcName {
+				assert.Equal(t, *backendRef.Weight, int32(100))
+			}
+		}
+		assert.True(t, found)
+	})
+}
+
+func TestGatewayAPIV1Beta1Router_getSessionAffinityRouteRules(t *testing.T) {
+	canary := newTestGatewayAPICanary()
+	mocks := newFixture(canary)
+	cookieKey := "flagger-cookie"
+	canary.Spec.Analysis.SessionAffinity = &flaggerv1.SessionAffinity{
+		CookieName: cookieKey,
+		MaxAge:     300,
+	}
+
+	router := &GatewayAPIV1Beta1Router{
+		gatewayAPIClient: mocks.meshClient,
+		kubeClient:       mocks.kubeClient,
+		logger:           mocks.logger,
+	}
+	_, pSvcName, cSvcName := canary.GetServiceNames()
+	weightedRouteRule := &v1beta1.HTTPRouteRule{
+		BackendRefs: []v1beta1.HTTPBackendRef{
+			{
+				BackendRef: router.makeBackendRef(pSvcName, initialPrimaryWeight, canary.Spec.Service.Port),
+			},
+			{
+				BackendRef: router.makeBackendRef(cSvcName, initialCanaryWeight, canary.Spec.Service.Port),
+			},
+		},
+	}
+	rules, err := router.getSessionAffinityRouteRules(canary, 10, weightedRouteRule)
+	require.NoError(t, err)
+	assert.Equal(t, len(rules), 2)
+	assert.True(t, strings.HasPrefix(canary.Status.SessionAffinityCookie, cookieKey))
+
+	stickyRule := rules[0]
+	cookieMatch := stickyRule.Matches[0].Headers[0]
+	assert.Equal(t, *cookieMatch.Type, v1beta1.HeaderMatchRegularExpression)
+	assert.Equal(t, string(cookieMatch.Name), cookieHeader)
+	assert.Contains(t, cookieMatch.Value, cookieKey)
+
+	assert.Equal(t, len(stickyRule.BackendRefs), 2)
+	for _, backendRef := range stickyRule.BackendRefs {
+		if string(backendRef.BackendRef.Name) == pSvcName {
+			assert.Equal(t, *backendRef.BackendRef.Weight, int32(0))
+		}
+		if string(backendRef.BackendRef.Name) == cSvcName {
+			assert.Equal(t, *backendRef.BackendRef.Weight, int32(100))
+		}
+	}
+
+	weightedRule := rules[1]
+	var found bool
+	for _, backendRef := range weightedRule.BackendRefs {
+		if string(backendRef.Name) == cSvcName {
+			found = true
+			filter := backendRef.Filters[0]
+			assert.Equal(t, filter.Type, v1beta1.HTTPRouteFilterResponseHeaderModifier)
+			assert.NotNil(t, filter.ResponseHeaderModifier)
+			assert.Equal(t, string(filter.ResponseHeaderModifier.Add[0].Name), setCookieHeader)
+			assert.Equal(t, filter.ResponseHeaderModifier.Add[0].Value, fmt.Sprintf("%s; %s=%d", canary.Status.SessionAffinityCookie, maxAgeAttr, 300))
+		}
+	}
+	assert.True(t, found)
+
+	rules, err = router.getSessionAffinityRouteRules(canary, 0, weightedRouteRule)
+	assert.Empty(t, canary.Status.SessionAffinityCookie)
+	assert.Contains(t, canary.Status.PreviousSessionAffinityCookie, cookieKey)
+
+	stickyRule = rules[0]
+	cookieMatch = stickyRule.Matches[0].Headers[0]
+	assert.Equal(t, *cookieMatch.Type, v1beta1.HeaderMatchRegularExpression)
+	assert.Equal(t, string(cookieMatch.Name), cookieHeader)
+	assert.Contains(t, cookieMatch.Value, cookieKey)
+
+	assert.Equal(t, stickyRule.Filters[0].Type, v1beta1.HTTPRouteFilterResponseHeaderModifier)
+	headerModifier := stickyRule.Filters[0].ResponseHeaderModifier
+	assert.NotNil(t, headerModifier)
+	assert.Equal(t, string(headerModifier.Add[0].Name), setCookieHeader)
+	assert.Equal(t, headerModifier.Add[0].Value, fmt.Sprintf("%s; %s=%d", canary.Status.PreviousSessionAffinityCookie, maxAgeAttr, -1))
 }

--- a/test/gatewayapi/install.sh
+++ b/test/gatewayapi/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-CONTOUR_VER="v1.23.0"
+CONTOUR_VER="v1.26.0"
 GATEWAY_API_VER="v1beta1"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KUSTOMIZE_VERSION=4.5.2

--- a/test/gatewayapi/run.sh
+++ b/test/gatewayapi/run.sh
@@ -11,3 +11,4 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 "$DIR"/test-canary.sh
 "$DIR"/test-bg.sh
 "$DIR"/test-ab.sh
+"$DIR"/test-session-affinity.sh

--- a/test/gatewayapi/test-session-affinity.sh
+++ b/test/gatewayapi/test-session-affinity.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# This script runs e2e tests for progressive traffic shifting with session affinity, Canary analysis and promotion
+# Prerequisites: Kubernetes Kind and Contour with GatewayAPI
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source ${REPO_ROOT}/test/gatewayapi/test-utils.sh
+
+create_latency_metric_template
+create_error_rate_metric_template
+
+echo '>>> Deploy podinfo in sa-test namespace'
+kubectl create ns sa-test
+kubectl apply -f ${REPO_ROOT}/test/workloads/secret.yaml -n sa-test
+kubectl apply -f ${REPO_ROOT}/test/workloads/deployment.yaml -n sa-test
+
+echo '>>> Installing Canary'
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo
+  namespace: sa-test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  progressDeadlineSeconds: 60
+  service:
+    port: 9898
+    portName: http
+    hosts:
+     - localproject.contour.io
+    gatewayRefs:
+      - name: contour
+        namespace: projectcontour
+  analysis:
+    interval: 15s
+    threshold: 15
+    maxWeight: 50
+    stepWeight: 10
+    sessionAffinity:
+      cookieName: flagger-cookie
+    metrics:
+      - name: error-rate
+        templateRef:
+          name: error-rate
+          namespace: flagger-system
+        thresholdRange:
+          max: 1
+        interval: 1m
+      - name: latency
+        templateRef:
+          name: latency
+          namespace: flagger-system
+        thresholdRange:
+          max: 0.5
+        interval: 30s
+    webhooks:
+      - name: load-test
+        type: rollout
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          cmd: "hey -z 2m -q 10 -c 2 -host localproject.contour.io http://envoy-contour.projectcontour/"
+          logCmdOutput: "true"
+EOF
+
+check_primary "sa-test"
+
+display_httproute "sa-test"
+
+echo '>>> Port forwarding load balancer'
+kubectl port-forward -n projectcontour svc/envoy-contour 8888:80 2>&1 > /dev/null &
+pf_pid=$!
+
+cleanup() {
+    echo ">> Killing port forward process ${pf_pid}"
+    kill -9 $pf_pid
+}
+trap "cleanup" EXIT SIGINT
+
+echo '>>> Triggering canary deployment'
+kubectl -n sa-test set image deployment/podinfo podinfod=stefanprodan/podinfo:6.1.0
+
+echo '>>> Waiting for initial traffic shift'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n sa-test get canary podinfo -o=jsonpath='{.status.canaryWeight}' | grep '10' && ok=true || ok=false
+    sleep 5
+    kubectl -n flagger-system logs deployment/flagger --tail 1
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+echo '>>> Verifying session affinity'
+if ! URL=http://localhost:8888 HOST=localproject.contour.io VERSION=6.1.0 COOKIE_NAME=flagger-cookie \
+    go run ${REPO_ROOT}/test/gatewayapi/verify_session_affinity.go; then
+    echo "failed to verify session affinity"
+    exit $?
+fi
+
+echo '>>> Waiting for canary promotion'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n sa-test describe deployment/podinfo-primary | grep '6.1.0' && ok=true || ok=false
+    sleep 10
+    kubectl -n flagger-system logs deployment/flagger --tail 1
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+display_httproute "sa-test"
+
+echo '>>> Waiting for canary finalization'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n sa-test get canary/podinfo | grep 'Succeeded' && ok=true || ok=false
+    sleep 5
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n flagger-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+echo '>>> Verifying cookie cleanup'
+canary_cookie=$(kubectl -n sa-test get canary podinfo -o=jsonpath='{.status.previousSessionAffinityCookie}' | xargs)
+response=$(curl -H "Host: localproject.contour.io" -H "Cookie: $canary_cookie" -D - http://localhost:8888)
+
+if [[ $response == *"$canary_cookie"* ]]; then
+  echo "✔ Found previous cookie in response"
+else
+  echo "⨯ Previous cookie ${canary_cookie} not found in response"
+  exit 1
+fi
+
+if [[ $response == *"Max-Age=-1"* ]]; then
+  echo "✔ Found Max-Age attribute in cookie"
+else
+  echo "⨯ Max-Age attribute not present in cookie"
+  exit 1
+fi
+
+echo '✔ Canary release with session affinity promotion test passed'
+
+kubectl delete -n sa-test canary podinfo

--- a/test/gatewayapi/verify_session_affinity.go
+++ b/test/gatewayapi/verify_session_affinity.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+var c = make(chan string, 1)
+var mu sync.Mutex
+var try = true
+var timeout = time.Second * 10
+
+func main() {
+	url := os.Getenv("URL")
+	host := os.Getenv("HOST")
+	version := os.Getenv("VERSION")
+	cookieName := os.Getenv("COOKIE_NAME")
+
+	// Generate traffic
+	for i := 0; i < 10; i++ {
+		go tryUntilCanaryIsHit(url, host, version, cookieName)
+	}
+
+	select {
+	// If we receive a cookie, then try to verify that we are always routed to the
+	// Canary deployment based on the cookie.
+	case cookie := <-c:
+		mu.Lock()
+		try = false
+		mu.Unlock()
+
+		for i := 0; i < 5; i++ {
+			headers := map[string]string{
+				"Cookie": cookie,
+			}
+			body, _, err := sendRequest(url, host, headers)
+			if err != nil {
+				log.Fatalf("failed to send request to verify cookie based routing: %v", err)
+			}
+			if !strings.Contains(body, version) {
+				log.Fatalf("received response from primary deployment instead of canary deployment")
+			}
+		}
+
+		log.Println("✔ successfully verified session affinity")
+	case <-time.After(timeout):
+		log.Fatal("timed out waiting for canary hit")
+	}
+}
+
+// sendRequest sends a request to the URL with the provided host and headers.
+// It returns the response body and cookies or an error.
+func sendRequest(url, host string, headers map[string]string) (string, []*http.Cookie, error) {
+	client := http.DefaultClient
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	req.Host = host
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return string(body), resp.Cookies(), nil
+}
+
+// tryUntilCanaryIsHit is a recursive function that tries to send request and
+// either sends the cookie back to the main thread (if received) or re-sends
+// the request.
+func tryUntilCanaryIsHit(url, host, version, cookieName string) {
+	mu.Lock()
+	if !try {
+		mu.Unlock()
+		return
+	}
+	mu.Unlock()
+
+	body, cookies, err := sendRequest(url, host, nil)
+	if err != nil {
+		log.Printf("warning: failed to send request: %s", err)
+		return
+	}
+	if strings.Contains(body, version) {
+		if cookies[0].Name == cookieName {
+			c <- fmt.Sprintf("%s=%s", cookies[0].Name, cookies[0].Value)
+			return
+		}
+	}
+
+	tryUntilCanaryIsHit(url, host, version, cookieName)
+	return
+}


### PR DESCRIPTION
Add support for Canary releases with session affinity for Gateway API. This enables any Gateway API implementation that supports [`ResponseHeaderModifier`](https://github.com/kubernetes-sigs/gateway-api/blob/3d22aa5a08413222cb79e6b2e245870360434614/apis/v1beta1/httproute_types.go#L651) to be used with session affinity.

For more info, see https://docs.flagger.app/usage/deployment-strategies#canary-release-with-session-affinity