### PR TITLE
Retry Counter for Rollout Hook

### DIFF
--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -1077,6 +1077,9 @@ spec:
                             description: URL address of this webhook
                             type: string
                             format: url
+                          retrylimit:
+                            type: integer
+                            description: Number of retry if Rollout hook failed
                           timeout:
                             description: Request timeout for this webhook
                             type: string

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -390,6 +390,11 @@ type CanaryWebhook struct {
 	// Metadata (key-value pairs) for this webhook
 	// +optional
 	Metadata *map[string]string `json:"metadata,omitempty"`
+
+	// FailureThreshold for rollout hook
+	// +optional
+	RetryLimit int `json:"retrylimit,omitempty"`
+
 }
 
 // CanaryWebhookPayload holds the deployment info and metadata sent to webhooks


### PR DESCRIPTION
Adding support for retry in case rollout hook get error or no response. 

PR for issue https://github.com/fluxcd/flagger/issues/1501 
