### PR TITLE
set original node selector value when finalizing service

### DIFF
--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -262,7 +262,7 @@ func (c *KubernetesDefaultRouter) Finalize(canary *flaggerv1.Canary) error {
 				return fmt.Errorf("service %s update error: %w", clone.Name, err)
 			}
 		} else {
-			err = c.reconcileService(canary, apexName, canary.Spec.TargetRef.Name, nil)
+			err = c.reconcileService(canary, apexName, c.labelValue, nil)
 			if err != nil {
 				return fmt.Errorf("reconcileService failed: %w", err)
 			}


### PR DESCRIPTION
As issue https://github.com/fluxcd/flagger/issues/1534 reported, the reverted service does not have the same selector as the original one, as a result the reverted service has not endpoints.

KubernetesDefaultRouter has the original selector label and selector value, we should use that instead of canary.Spec.TargetRef.Name

Signed-off-by: rye-sw <rye@stairwell.com>