### PR TITLE
controller: wait for canary deployment to be ready before removing finalizers

### DIFF
--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -75,9 +75,10 @@ func (c *Controller) finalize(old interface{}) error {
 	// Ensure that targetRef has met a ready state
 	c.logger.Infof("Checking if canary is ready %s.%s", canary.Name, canary.Namespace)
 	backoff := wait.Backoff{
-		Duration: time.Second,
+		Duration: time.Second * 3,
 		Factor:   2,
 		Cap:      canary.GetAnalysisInterval(),
+		Steps:    4,
 	}
 	retry.OnError(backoff, func(err error) bool {
 		return err.Error() == "retriable error"


### PR DESCRIPTION
Fix the waiting logic to actually wait for the canary deployment to be ready before continuing with the rest of the finalization logic. Previously, the canary deployment was not being checked for a ready status due to the the absence of the `Steps` field in the specified backoff.

Fixes: #1550 