### PR TITLE
Istio Canary TCP service support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ test-codegen:
 test: test-fmt test-codegen
 	go test ./...
 
+test-coverage: test-fmt test-codegen
+	go test -coverprofile cover.out ./...
+	go tool cover -html=cover.out
+	rm cover.out
+
 crd:
 	cat artifacts/flagger/crd.yaml > charts/flagger/crds/crd.yaml
 	cat artifacts/flagger/crd.yaml > kustomize/base/flagger/crd.yaml

--- a/pkg/apis/istio/v1alpha3/virtual_service.go
+++ b/pkg/apis/istio/v1alpha3/virtual_service.go
@@ -597,7 +597,7 @@ type TCPRoute struct {
 	// Currently, only one destination is allowed for TCP services. When TCP
 	// weighted routing support is introduced in Envoy, multiple destinations
 	// with weights can be specified.
-	Route HTTPRouteDestination `json:"route"`
+	Route []HTTPRouteDestination `json:"route"`
 }
 
 // L4 connection match attributes. Note that L4 connection matching support

--- a/pkg/apis/istio/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1alpha3/zz_generated.deepcopy.go
@@ -848,7 +848,13 @@ func (in *TCPRoute) DeepCopyInto(out *TCPRoute) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Route.DeepCopyInto(&out.Route)
+	if in.Route != nil {
+		in, out := &in.Route, &out.Route
+		*out = make([]HTTPRouteDestination, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This PR is a response to the feature requested in https://github.com/fluxcd/flagger/issues/1556

The changes contained in the PR only add support for TCP Canary deployments if the user has configured Flagger to use the istio `meshProvider`.
When the user deploys their `Canary` document, Flagger will check if the `Canary.service.appProtocol` key has been set to `TCP` (case insensitive). 
```yaml
apiVersion: flagger.app/v1beta1
kind: Canary
metadata:
...
spec:
...
  service:
    appProtocol: tcp
...
```

If the value equals `TCP` then it will deploy the `VirtualService` document with a `tcp` section (instead of the default `http` section that it uses now without this feature). After the `VirtualService` document is deployed it will look similar to the below example:
```yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
   name: tcp-service
  namespace: test
  ownerReferences:
  - apiVersion: flagger.app/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: Canary
    name: tcp-service
spec:
  gateways:
  - istio-ingress/tcp-service-gateway
  hosts:
  - '*'
  tcp:
  - route:
    - destination:
        host: tcp-service-primary
        port:
          number: 7070
      weight: 100
    - destination:
        host: tcp-service-canary
        port:
          number: 7070
      weight: 0
```
Notice the `tcp` section. Once the `Canary` switches to `Progressing` phase Flagger will be able to adjust the `weight` keys as expected during the evaluation period. Once completed, Flagger can promote the canary to the primary as expected. Likewise, if the canary fails the analysis, it will go into an `error` state just like it does normally.

If the user doesn't set the `Canary.service.appProtocol` key or they set it to anything other than `TCP` (like `http`) the `Canary` will be treated as it is now (without these changes) and Flagger will deploy the `VirtualService` document with the `http` section and it will also be able to update the weights as it normally does during canary deployments.

Closes: #1556