### PR TITLE
Allow Newrelic provider to retrieve different query responses

### DIFF
--- a/pkg/metrics/providers/newrelic.go
+++ b/pkg/metrics/providers/newrelic.go
@@ -47,7 +47,7 @@ type NewRelicProvider struct {
 
 type newRelicResponse struct {
 	Results []struct {
-		Result *float64 `json:"result"`
+		Field map[string]*float64 `json:"result"`
 	} `json:"results"`
 }
 


### PR DESCRIPTION
Modifies the newrelic response struct to allow any string on the key field and transforms it to `result`.
[#1584](https://github.com/fluxcd/flagger/issues/1584)