### PR TITLE
scheduler: fail canary according to progress deadline

### DIFF
--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -124,7 +124,7 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configMap := newDaemonSetControllerTestConfigMap()
 		configMapProjected := newDaemonSetControllerTestConfigProjected()
 
-		err := mocks.controller.Initialize(mocks.canary)
+		_, err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})

--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Controller interface {
-	IsPrimaryReady(canary *flaggerv1.Canary) error
+	IsPrimaryReady(canary *flaggerv1.Canary) (bool, error)
 	IsCanaryReady(canary *flaggerv1.Canary) (bool, error)
 	GetMetadata(canary *flaggerv1.Canary) (string, string, map[string]int32, error)
 	SyncStatus(canary *flaggerv1.Canary, status flaggerv1.CanaryStatus) error
@@ -29,7 +29,7 @@ type Controller interface {
 	SetStatusWeight(canary *flaggerv1.Canary, val int) error
 	SetStatusIterations(canary *flaggerv1.Canary, val int) error
 	SetStatusPhase(canary *flaggerv1.Canary, phase flaggerv1.CanaryPhase) error
-	Initialize(canary *flaggerv1.Canary) error
+	Initialize(canary *flaggerv1.Canary) (bool, error)
 	Promote(canary *flaggerv1.Canary) error
 	HasTargetChanged(canary *flaggerv1.Canary) (bool, error)
 	HaveDependenciesChanged(canary *flaggerv1.Canary) (bool, error)

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -34,7 +34,7 @@ import (
 func TestDaemonSetController_Sync_ConsistentNaming(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), fmt.Sprintf("%s-primary", dc.name), metav1.GetOptions{})
@@ -56,7 +56,7 @@ func TestDaemonSetController_Sync_ConsistentNaming(t *testing.T) {
 func TestDaemonSetController_Sync_InconsistentNaming(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo-service", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), fmt.Sprintf("%s-primary", dc.name), metav1.GetOptions{})
@@ -75,7 +75,7 @@ func TestDaemonSetController_Sync_InconsistentNaming(t *testing.T) {
 func TestDaemonSetController_Promote(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	dae2 := newDaemonSetControllerTestPodInfoV2()
@@ -116,7 +116,7 @@ func TestDaemonSetController_NoConfigTracking(t *testing.T) {
 	mocks := newDaemonSetFixture(dc)
 	mocks.controller.configTracker = &NopTracker{}
 
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
@@ -132,7 +132,7 @@ func TestDaemonSetController_NoConfigTracking(t *testing.T) {
 func TestDaemonSetController_HasTargetChanged(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	// save last applied hash
@@ -221,7 +221,7 @@ func TestDaemonSetController_Scale(t *testing.T) {
 	t.Run("ScaleToZero", func(t *testing.T) {
 		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 		mocks := newDaemonSetFixture(dc)
-		err := mocks.controller.Initialize(mocks.canary)
+		_, err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		err = mocks.controller.ScaleToZero(mocks.canary)
@@ -238,7 +238,7 @@ func TestDaemonSetController_Scale(t *testing.T) {
 	t.Run("ScaleFromZeo", func(t *testing.T) {
 		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 		mocks := newDaemonSetFixture(dc)
-		err := mocks.controller.Initialize(mocks.canary)
+		_, err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		err = mocks.controller.ScaleFromZero(mocks.canary)
@@ -257,7 +257,7 @@ func TestDaemonSetController_Scale(t *testing.T) {
 func TestDaemonSetController_Finalize(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.Finalize(mocks.canary)

--- a/pkg/canary/daemonset_ready_test.go
+++ b/pkg/canary/daemonset_ready_test.go
@@ -30,10 +30,10 @@ import (
 func TestDaemonSetController_IsReady(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
-	err = mocks.controller.IsPrimaryReady(mocks.canary)
+	_, err = mocks.controller.IsPrimaryReady(mocks.canary)
 	require.NoError(t, err)
 
 	_, err = mocks.controller.IsCanaryReady(mocks.canary)

--- a/pkg/canary/daemonset_status_test.go
+++ b/pkg/canary/daemonset_status_test.go
@@ -30,7 +30,7 @@ import (
 func TestDaemonSetController_SyncStatus(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	status := flaggerv1.CanaryStatus{
@@ -55,7 +55,7 @@ func TestDaemonSetController_SyncStatus(t *testing.T) {
 func TestDaemonSetController_SetFailedChecks(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
@@ -69,7 +69,7 @@ func TestDaemonSetController_SetFailedChecks(t *testing.T) {
 func TestDaemonSetController_SetState(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)
-	err := mocks.controller.Initialize(mocks.canary)
+	_, err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -44,20 +44,20 @@ type DeploymentController struct {
 }
 
 // Initialize creates the primary deployment if it does not exist.
-func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
+func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (bool, error) {
 	if err := c.createPrimaryDeployment(cd, c.includeLabelPrefix); err != nil {
-		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
+		return true, fmt.Errorf("createPrimaryDeployment failed: %w", err)
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
 		if !cd.SkipAnalysis() {
-			if err := c.IsPrimaryReady(cd); err != nil {
-				return fmt.Errorf("%w", err)
+			if retriable, err := c.IsPrimaryReady(cd); err != nil {
+				return retriable, fmt.Errorf("%w", err)
 			}
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // Promote copies the pod spec, secrets and config maps from canary to primary

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -55,7 +55,7 @@ type deploymentConfigs struct {
 }
 
 func (d deploymentControllerFixture) initializeCanary(t *testing.T) {
-	err := d.controller.Initialize(d.canary)
+	_, err := d.controller.Initialize(d.canary)
 	require.Error(t, err) // not ready yet
 
 	primaryName := fmt.Sprintf("%s-primary", d.canary.Spec.TargetRef.Name)
@@ -73,7 +73,8 @@ func (d deploymentControllerFixture) initializeCanary(t *testing.T) {
 	_, err = d.controller.kubeClient.AppsV1().Deployments(d.canary.Namespace).Update(context.TODO(), p, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	require.NoError(t, d.controller.Initialize(d.canary))
+	_, err = d.controller.Initialize(d.canary)
+	require.NoError(t, err)
 }
 
 func newDeploymentFixture(dc deploymentConfigs) deploymentControllerFixture {

--- a/pkg/canary/deployment_ready_test.go
+++ b/pkg/canary/deployment_ready_test.go
@@ -32,7 +32,7 @@ func TestDeploymentController_IsReady(t *testing.T) {
 	mocks := newDeploymentFixture(dc)
 	mocks.controller.Initialize(mocks.canary)
 
-	err := mocks.controller.IsPrimaryReady(mocks.canary)
+	_, err := mocks.controller.IsPrimaryReady(mocks.canary)
 	require.Error(t, err)
 
 	_, err = mocks.controller.IsCanaryReady(mocks.canary)


### PR DESCRIPTION
Modify `canary.IsPrimaryReady()` and `canary.Initialize()` to return a boolean indicating if the error is retriable. Modify the scheduler to rollback the analysis and mark the Canary object as failed if the above two functions or `canary.IsCanaryReady()` returns false along with an error.

fix: #1247
fix: #1592
fix: #1591
fix: #1578