### PR TITLE
omitempty of Canary status to allow better marshalling out of Kubernetes resource

### DIFF
--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -46,7 +46,7 @@ type Canary struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   CanarySpec   `json:"spec"`
-	Status CanaryStatus `json:"status"`
+	Status CanaryStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
We are using flagger programmatically, and are marshalling the resource back out for deployment. The lack of omitempty of the Canary is causing issues with our validation through kubeconform, as the null in lastTransitionTime does not conform with date-time https://github.com/fluxcd/flagger/blob/main/artifacts/flagger/crd.yaml#L1197