### PR TITLE
fix(gloo): Update reconciler to detect change in gloo upstream spec

### DIFF
--- a/test/gloo/test-canary.sh
+++ b/test/gloo/test-canary.sh
@@ -117,6 +117,47 @@ done
 
 echo '✔ Canary initialization test passed'
 
+echo '>>> Waiting for primary spec to be updated'
+
+# Update gloo upstream on slow start config which will trigger update on flagger upstreams
+cat <<EOF | kubectl apply -f -
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: config-upstream
+  namespace: gloo-system
+spec:
+  static:
+    hosts:
+    - addr: "example.com"
+      port: 80
+  connectionConfig:
+    connectTimeout: 2s
+    maxRequestsPerConnection: 51
+  loadBalancerConfig:
+    roundRobin:
+      slowStartConfig:
+        slowStartWindow: 2m
+        minWeightPercent: 20
+EOF
+
+retries=50
+count=0
+ok=false
+until ${ok}; do
+    kubectl -n test get upstream/test-podinfo-canaryupstream-80 -ojson | jq '.spec.loadBalancerConfig.roundRobin.slowStartConfig.minWeightPercent' | grep '20' && ok=true || ok=false
+    
+    sleep 5
+    count=$(($count + 1))
+    if [[ ${count} -eq ${retries} ]]; then
+        kubectl -n gloo-system logs deployment/flagger
+        echo "No more retries left"
+        exit 1
+    fi
+done
+
+echo '✔ Canary reconcilation test passed'
+
 echo '>>> Triggering canary deployment'
 kubectl -n test set image deployment/podinfo podinfod=ghcr.io/stefanprodan/podinfo:6.0.1
 

--- a/test/gloo/test-canary.sh
+++ b/test/gloo/test-canary.sh
@@ -120,26 +120,7 @@ echo '✔ Canary initialization test passed'
 echo '>>> Waiting for primary spec to be updated'
 
 # Update gloo upstream on slow start config which will trigger update on flagger upstreams
-cat <<EOF | kubectl apply -f -
-apiVersion: gloo.solo.io/v1
-kind: Upstream
-metadata:
-  name: config-upstream
-  namespace: gloo-system
-spec:
-  static:
-    hosts:
-    - addr: "example.com"
-      port: 80
-  connectionConfig:
-    connectTimeout: 2s
-    maxRequestsPerConnection: 51
-  loadBalancerConfig:
-    roundRobin:
-      slowStartConfig:
-        slowStartWindow: 2m
-        minWeightPercent: 20
-EOF
+kubectl -n gloo-system patch upstream config-upstream --type json --patch='[ { "op": "replace", "path": "/spec/loadBalancerConfig/roundRobin/slowStartConfig/minWeightPercent", "value": 20 } ]'
 
 retries=50
 count=0


### PR DESCRIPTION
**Problem:**
The reconciler is not detecting changes in gloo upstream spec. When the slow start config is added or updated in gloo upstream, the same config is not propagated to existing flagger upstreams. 

**Reproducing Step:**
- create gloo upstream 

```
apiVersion: gloo.solo.io/v1
kind: Upstream
metadata:
  name: config-upstream
  namespace: gloo-system
```
- create canary that has upstream reference to gloo

```
apiVersion: flagger.app/v1beta1
kind: Canary
metadata:
  name: podinfo
  namespace: test
spec:
  upstreamRef:
    apiVersion: gloo.solo.io/v1
    kind: Upstream
    name: config-upstream
    namespace: gloo-system
  provider: gloo
```
- add/modify slow start config in gloo upstream 
```
apiVersion: gloo.solo.io/v1
kind: Upstream
metadata:
  name: config-upstream
  namespace: gloo-system
spec:
  loadBalancerConfig:
    roundRobin:
      slowStartConfig:
        slowStartWindow: 2m
        minWeightPercent: 5
```
- flagger upstreams (primary and canary) will not pick up the updated slow start config

**In PR:**
- update reconciler to detect diff in load balancer config for gloo vs flagger upstreams 
- when a change is detected, update flagger upstream load balancer with the latest config
- add integration test to verify the fix