### PR TITLE
Add omitempty to statuses to allow better marshalling

### DIFF
--- a/pkg/apis/flagger/v1beta1/alert.go
+++ b/pkg/apis/flagger/v1beta1/alert.go
@@ -34,7 +34,7 @@ type AlertProvider struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   AlertProviderSpec   `json:"spec"`
-	Status AlertProviderStatus `json:"status"`
+	Status AlertProviderStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -46,7 +46,7 @@ type Canary struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   CanarySpec   `json:"spec"`
-	Status CanaryStatus `json:"status"`
+	Status CanaryStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/flagger/v1beta1/metric.go
+++ b/pkg/apis/flagger/v1beta1/metric.go
@@ -36,7 +36,7 @@ type MetricTemplate struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   MetricTemplateSpec   `json:"spec"`
-	Status MetricTemplateStatus `json:"status"`
+	Status MetricTemplateStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
We are using flagger programmatically, and are marshalling the resource back out for deployment. The lack of omitempty in flagger resources such as the canary is causing issues with our validation through kubeconform, as the null in lastTransitionTime does not conform with date-time.

Cross referencing with other Kubernetes CRDs show most of them allow and omit empty status, so it will be good have something similar here.