### PR TITLE
block panic when prom returns range vector

### DIFF
--- a/pkg/metrics/providers/errors.go
+++ b/pkg/metrics/providers/errors.go
@@ -19,5 +19,6 @@ package providers
 import "errors"
 
 var (
-	ErrNoValuesFound = errors.New("no values found")
+	ErrNoValuesFound          = errors.New("no values found")
+	ErrMultipleValuesReturned = errors.New("query returned multiple values")
 )

--- a/pkg/metrics/providers/prometheus.go
+++ b/pkg/metrics/providers/prometheus.go
@@ -51,7 +51,8 @@ type prometheusResponse struct {
 			Metric struct {
 				Name string `json:"name"`
 			}
-			Value []interface{} `json:"value"`
+			Value  []interface{} `json:"value"`
+			Values []interface{} `json:"values"`
 		}
 	}
 }
@@ -147,6 +148,9 @@ func (p *PrometheusProvider) RunQuery(query string) (float64, error) {
 
 	var value *float64
 	for _, v := range result.Data.Result {
+		if v.Values != nil {
+			return 0, fmt.Errorf("%w", ErrMultipleValuesReturned)
+		}
 		metricValue := v.Value[1]
 		switch metricValue.(type) {
 		case string:


### PR DESCRIPTION
Signed-off-by: Tanner Altares <ta924@yahoo.com>

This is a PR to address [1636](https://github.com/fluxcd/flagger/issues/1636 ), which keeps flagger from throwing a panic in the event the prom query returns a range vector.