### PR TITLE
(bugfix) Issue-1464 issue resolved

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -307,6 +307,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 				Infof("VirtualService %s.%s updated", virtualService.GetName(), canary.Namespace)
 		}
 	}
+
 	ignoreCmpOptions := []cmp.Option{
 		cmpopts.IgnoreFields(istiov1beta1.HTTPRouteDestination{}, "Weight"),
 		cmpopts.IgnoreFields(istiov1beta1.HTTPRoute{}, "Mirror", "MirrorPercentage"),

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -295,8 +295,6 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 
 	if canary.Spec.Service.Delegation {
 		// delegate VirtualService requires the hosts and gateway empty.
-		virtualService.Spec.Gateways = []string{}
-		virtualService.Spec.Hosts = []string{}
 		newSpec.Hosts = []string{}
 		newSpec.Gateways = []string{}
 	}
@@ -332,7 +330,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 		)
 		labelsDiff := cmp.Diff(newMetadata.Labels, virtualService.Labels, cmpopts.EquateEmpty())
 		annotationsDiff := cmp.Diff(newMetadata.Annotations, virtualService.Annotations, cmpopts.EquateEmpty())
-		if specDiff != "" || labelsDiff != "" || annotationsDiff != "" || canary.Spec.Service.Delegation {
+		if specDiff != "" || labelsDiff != "" || annotationsDiff != "" {
 			vtClone := virtualService.DeepCopy()
 			vtClone.Spec = newSpec
 			vtClone.ObjectMeta.Annotations = newMetadata.Annotations
@@ -340,7 +338,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 			//If annotation kubectl.kubernetes.io/last-applied-configuration is present no need to duplicate
 			//serialization.  If not present store the serialized object in annotation
 			//flagger.kubernetes.app/original-configuration
-			if _, ok := vtClone.Annotations[kubectlAnnotation]; !ok && specDiff != "" || canary.Spec.Service.Delegation {
+			if _, ok := vtClone.Annotations[kubectlAnnotation]; !ok && specDiff != ""{
 				b, err := json.Marshal(virtualService.Spec)
 				if err != nil {
 					ir.logger.Warnf("Unable to marshal VS %s for orig-configuration annotation", virtualService.Name)

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -293,7 +293,9 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 	} else if err != nil {
 		return fmt.Errorf("VirtualService %s.%s get query error %v", apexName, canary.Namespace, err)
 	}
+
 	if canary.Spec.Service.Delegation {
+		// delegate VirtualService requires the hosts and gateway empty.
 		virtualService.Spec.Gateways = []string{}
 		virtualService.Spec.Hosts = []string{}
 		if !reflect.DeepEqual(newSpec, istiov1beta1.VirtualServiceSpec{}) {
@@ -341,6 +343,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 			vtClone.Spec = newSpec
 			vtClone.ObjectMeta.Annotations = newMetadata.Annotations
 			vtClone.ObjectMeta.Labels = newMetadata.Labels
+
 			//If annotation kubectl.kubernetes.io/last-applied-configuration is present no need to duplicate
 			//serialization.  If not present store the serialized object in annotation
 			//flagger.kubernetes.app/original-configuration


### PR DESCRIPTION
# summary

 if `delegation: true` is set while a VirtualService has already been created by Flagger, there are no changes to the newSpec. Therefore, I suspect that the hosts and gateway are not removed.

https://github.com/fluxcd/flagger/blob/9a0c6e7e54e3e822f9b505f3fb404bec77aeae55/pkg/router/istio.go#L296-L300

https://github.com/fluxcd/flagger/blob/9a0c6e7e54e3e822f9b505f3fb404bec77aeae55/pkg/router/istio.go#L333

[MEMO] Code of the relevant part
https://github.com/fluxcd/flagger/blob/9a0c6e7e54e3e822f9b505f3fb404bec77aeae55/pkg/router/istio.go#L325-L364

※ This is just a suggestion for now, and there may be a better way to do it.

reference)
https://github.com/fluxcd/flagger/issues/1464