### PR TITLE
loadtester: add support for annotation on service account

### DIFF
--- a/charts/loadtester/templates/rbac.yaml
+++ b/charts/loadtester/templates/rbac.yaml
@@ -51,4 +51,7 @@ metadata:
     app.kubernetes.io/name: {{ template "loadtester.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations: {{ tpl (toYaml .Values.rbac.serviceAccountAnnotations) . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -54,6 +54,8 @@ rbac:
   #   resources: ["pods"]
   #   verbs: ["list", "get"]
   rules: []
+  # annotations to add to the service account
+  serviceAccountAnnotations: {}
 
 # name of an existing service account to use - if not creating rbac resources
 serviceAccountName: ""


### PR DESCRIPTION
this adds support to add annotation on serviceaccount when rbac is enabled.