### PR TITLE
Fix removal of empty keys from flagger chart

### DIFF
--- a/charts/flagger/templates/account.yaml
+++ b/charts/flagger/templates/account.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "flagger.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
   {{- if .Values.serviceAccount.annotations }}
+  annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
   {{- end }}
   labels:

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -48,12 +48,12 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      {{- if .Values.controlplane.kubeconfig.secretName }}
       volumes:
-        {{- if .Values.controlplane.kubeconfig.secretName }}
         - name: kubeconfig
           secret:
             secretName: "{{ .Values.controlplane.kubeconfig.secretName }}"
-        {{- end }}
+      {{- end }}
         {{- if .Values.additionalVolumes }}
           {{- toYaml .Values.additionalVolumes | nindent 8 -}}
         {{- end }}
@@ -66,11 +66,11 @@ spec:
           securityContext:
 {{ toYaml .Values.securityContext.context | indent 12 }}
           {{- end }}
+          {{- if .Values.controlplane.kubeconfig.secretName }}
           volumeMounts:
-            {{- if .Values.controlplane.kubeconfig.secretName }}
             - name: kubeconfig
               mountPath: "/tmp/controlplane"
-            {{- end }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
If annotations is empty for serviceAccounts `annotations` shows as empty key while generating the helm chart. Same goes with `volumes` and `volumeMounts` in deployment.
This PR fix the above issue.