### PR TITLE
fix virtual service destination routes when match is set

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"slices"
 	"strings"
 	"time"
 
@@ -721,8 +720,7 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1b
 
 	// set destination port when an ingress gateway is specified
 	if canary.Spec.Service.PortDiscovery &&
-		(len(canary.Spec.Service.Gateways) > 0 &&
-			!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
+		!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
 		dest = istiov1beta1.HTTPRouteDestination{
 			Destination: istiov1beta1.Destination{
 				Host: host,

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -709,7 +709,7 @@ func mergeMatchConditions(canary, defaults []istiov1beta1.HTTPMatchRequest) []is
 	return merged
 }
 
-// makeDestination returns a destination weight for the specified host
+// makeDestination returns a an destination weight for the specified host
 func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1beta1.HTTPRouteDestination {
 	dest := istiov1beta1.HTTPRouteDestination{
 		Destination: istiov1beta1.Destination{
@@ -720,7 +720,8 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1b
 
 	// set destination port when an ingress gateway is specified
 	if canary.Spec.Service.PortDiscovery &&
-		!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
+		(len(canary.Spec.Service.Gateways) > 0 &&
+			canary.Spec.Service.Gateways[0] != "mesh" || canary.Spec.Service.Delegation) {
 		dest = istiov1beta1.HTTPRouteDestination{
 			Destination: istiov1beta1.Destination{
 				Host: host,


### PR DESCRIPTION
primary destination is duplicated on both virtual service routes when setting match rules as per the [istio a/b testing](https://docs.flagger.app/tutorials/istio-ab-testing) tutorial:

No weights set on analysis object:
```yaml
  analysis:
    interval: 15s
    iterations: 2
    match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
```

 The following is generated:

```yaml
  http:
  - match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    route:
    - destination:
        host: podinfo-primary
      weight: 100
    - destination:
        host: podinfo-canary
      weight: 0
  - route:
     - destination:
         host: podinfo-primary
       weight: 100
```

analysis values with weigths:
```yaml
  analysis:
    interval: 15s
    match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    maxWeight: 50
    stepWeight: 50
    threshold: 2
```

generates:
```yaml
  http:
  - match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    route:
    - destination:
        host: podinfo-primary
      weight: 50
    - destination:
        host: podinfo-canary
      weight: 50
  - route:
     - destination:
         host: podinfo-primary
       weight: 50
```

Logic comes from [here](https://github.com/fluxcd/flagger/blob/217db66a5ed0ddfca14f4dd56a5726adcb244a81/pkg/router/istio.go#L184-L187) and [here](https://github.com/fluxcd/flagger/blob/217db66a5ed0ddfca14f4dd56a5726adcb244a81/pkg/router/istio.go#L238-L262)

this PR makes canary the default destination from the canary route when  neither `maxWeight` or `stepWeight` are set on the `canary`
```yaml
  http:
  - match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    route:
    - destination:
        host: podinfo-primary
      weight: 0
    - destination:
        host: podinfo-canary
      weight: 100
  - route:
    - destination:
        host: podinfo-primary
       weight: 100
```

Additionally as per [istio docs](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination) If there is only one destination in a rule, it will receive all traffic so it probably makes sense to get rid of the weights altogether and only leave one destination on each route?