### PR TITLE
Allow passing of metrics server secret to flagger

### DIFF
--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -59,6 +59,7 @@ var (
 	kubeconfigQPS            int
 	kubeconfigBurst          int
 	metricsServer            string
+	metricsServerSecretRef   string
 	controlLoopInterval      time.Duration
 	logLevel                 string
 	port                     string
@@ -94,6 +95,7 @@ func init() {
 	flag.IntVar(&kubeconfigBurst, "kubeconfig-burst", 250, "Set Burst for kubeconfig.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&metricsServer, "metrics-server", "http://prometheus:9090", "Prometheus URL.")
+	flag.StringVar(&metricsServerSecretRef, "metrics-server-secret-ref", "", "Prometheus Secret Reference.")
 	flag.DurationVar(&controlLoopInterval, "control-loop-interval", 10*time.Second, "Kubernetes API sync interval.")
 	flag.StringVar(&logLevel, "log-level", "debug", "Log level can be: debug, info, warning, error.")
 	flag.StringVar(&port, "port", "8080", "Port to listen on.")
@@ -196,7 +198,7 @@ func main() {
 		logger.Infof("Watching namespace %s", namespace)
 	}
 
-	observerFactory, err := observers.NewFactory(metricsServer)
+	observerFactory, err := observers.NewFactoryWithSecret(metricsServer, metricsServerSecretRef)
 	if err != nil {
 		logger.Fatalf("Error building prometheus client: %s", err.Error())
 	}

--- a/pkg/metrics/observers/factory.go
+++ b/pkg/metrics/observers/factory.go
@@ -21,6 +21,7 @@ import (
 
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	"github.com/fluxcd/flagger/pkg/metrics/providers"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type Factory struct {
@@ -32,6 +33,27 @@ func NewFactory(metricsServer string) (*Factory, error) {
 		Type:      "prometheus",
 		Address:   metricsServer,
 		SecretRef: nil,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Factory{
+		Client: client,
+	}, nil
+}
+
+func NewFactoryWithSecret(metricsServer string, metricsServerSecretRef string) (*Factory, error) {
+	var secretRef *corev1.LocalObjectReference
+	if metricsServerSecretRef != "" {
+		secretRef = &corev1.LocalObjectReference{Name: metricsServerSecretRef}
+	} else {
+		secretRef = nil
+	}
+	client, err := providers.NewPrometheusProvider(flaggerv1.MetricTemplateProvider{
+		Type:      "prometheus",
+		Address:   metricsServer,
+		SecretRef: secretRef,
 	}, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
An attempt at fixing https://github.com/fluxcd/flagger/issues/1671.  I'm not much of a Go wizard, so it probably requires some cleanup.

This adds the ability to add `--metrics-server-secret-ref` to give the ability to auth against external Prometheus endpoints.