### PR TITLE
Fix Nginx request-duration query

### DIFF
--- a/pkg/metrics/observers/nginx.go
+++ b/pkg/metrics/observers/nginx.go
@@ -50,7 +50,7 @@ var nginxQueries = map[string]string{
 	"request-duration": `
 	sum(
 		rate(
-			nginx_ingress_controller_ingress_upstream_latency_seconds_sum{
+			nginx_ingress_controller_response_duration_seconds_sum{
 				namespace="{{ namespace }}",
 				ingress="{{ ingress }}",
 				canary!=""
@@ -60,7 +60,7 @@ var nginxQueries = map[string]string{
 	/ 
 	sum(
 		rate(
-			nginx_ingress_controller_ingress_upstream_latency_seconds_count{
+			nginx_ingress_controller_response_duration_seconds_count{
 				namespace="{{ namespace }}",
 				ingress="{{ ingress }}",
 				canary!=""

--- a/pkg/metrics/observers/nginx_test.go
+++ b/pkg/metrics/observers/nginx_test.go
@@ -89,7 +89,7 @@ func TestNginxObserver_GetRequestSuccessRate(t *testing.T) {
 }
 
 func TestNginxObserver_GetRequestDuration(t *testing.T) {
-	expected := ` sum( rate( nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ namespace="nginx", ingress="podinfo", canary!="" }[1m] ) ) / sum( rate( nginx_ingress_controller_ingress_upstream_latency_seconds_count{ namespace="nginx", ingress="podinfo", canary!="" }[1m] ) ) * 1000`
+	expected := ` sum( rate( nginx_ingress_controller_response_duration_seconds_sum{ namespace="nginx", ingress="podinfo", canary!="" }[1m] ) ) / sum( rate( nginx_ingress_controller_response_duration_seconds_count{ namespace="nginx", ingress="podinfo", canary!="" }[1m] ) ) * 1000`
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		promql := r.URL.Query()["query"][0]


### PR DESCRIPTION
`nginx_ingress_controller_ingress_upstream_latency_seconds_sum` measures the connection latency, not the time it takes the backend to respond.

Fixes #1685