### PR TITLE
Add validation for `primaryScalerReplicas` field in the CRD

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -129,9 +129,11 @@ spec:
                       type: object
                       properties:
                         minReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                         maxReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                 ingressRef:
                   description: Ingress selector
                   type: object

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -129,9 +129,11 @@ spec:
                       type: object
                       properties:
                         minReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                         maxReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                 ingressRef:
                   description: Ingress selector
                   type: object

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -129,9 +129,11 @@ spec:
                       type: object
                       properties:
                         minReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                         maxReplicas:
-                          type: number
+                          type: integer
+                          minimum: 1
                 ingressRef:
                   description: Ingress selector
                   type: object


### PR DESCRIPTION
Canary object right now accepts values lower than one (`1`) for `primaryScalerReplicas` counts. This results in Flagger keep trying to update primary HPA replica count, but failing. The validation is added to prevent the invalid object definition to be applied in the first place.