### PR TITLE
chart: add support for deploymentLabels

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -114,6 +114,15 @@ $ helm upgrade -i flagger flagger/flagger \
     --set meshProvider=traefik
 ```
 
+If you need to add labels to the flagger deployment or pods, you can pass the labels as parameters as shown below.
+
+```console
+helm upgrade -i flagger flagger/flagger \
+<other parameters> \
+--set podLabels.<labelName>=<labelValue> \
+--set deploymentLabels.<labelName>=<labelValue> 
+```
+
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
@@ -186,6 +195,8 @@ The following tables lists the configurable parameters of the Flagger chart and 
 | `podDisruptionBudget.minAvailable`   | The minimal number of available replicas that will be set in the PodDisruptionBudget                                                               | `1`                                   |
 | `noCrossNamespaceRefs`               | If `true`, cross namespace references to custom resources will be disabled                                                                         | `false`                               |
 | `namespace`                          | When specified, Flagger will restrict itself to watching Canary objects from that namespace                                                        | `""`                                  |
+| `deploymentLabels`                   | Labels to add to Flagger deployment                                                                                                                | `{}`                                  |
+| `podLabels`                          | Labels to add to pods of Flagger deployment                                                                                                        | `{}`                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- if .Values.deploymentLabels }}
+  {{- range $key, $value := .Values.deploymentLabels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -195,7 +195,11 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
 
+# Additional labels to be added to pods
 podLabels: {}
+
+# Additional labels to be added to deployments
+deploymentLabels: { }
 
 noCrossNamespaceRefs: false
 

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -81,6 +81,15 @@ $ helm upgrade -i flagger flagger/flagger \
 --set metricsServer=http://osm-prometheus.osm-system.svc:7070
 ```
 
+If you need to add labels to the flagger deployment or pods, you can pass the labels as parameters as shown below.
+
+```console
+helm upgrade -i flagger flagger/flagger \
+<other parameters> \
+--set podLabels.<labelName>=<labelValue> \
+--set deploymentLabels.<labelName>=<labelValue> 
+```
+
 You can install Flagger in any namespace as long as it can talk to the Prometheus service on port 9090.
 
 For ingress controllers, the install instructions are:


### PR DESCRIPTION
This PR adds support for configuring additional labels for the deployment using `deploymentLabels` in `values.yaml`.