### PR TITLE
feat: add `disableTLS` option for webhooks request

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -1135,6 +1135,9 @@ spec:
                           retries:
                             description: Number of retries for this webhook
                             type: number
+                          disableTLS:
+                            description: Disable TLS verification for this webhook
+                            type: boolean
                           metadata:
                             description: Metadata (key-value pairs) for this webhook
                             type: object

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -1135,6 +1135,9 @@ spec:
                           retries:
                             description: Number of retries for this webhook
                             type: number
+                          disableTLS:
+                            description: Disable TLS verification for this webhook
+                            type: boolean
                           metadata:
                             description: Metadata (key-value pairs) for this webhook
                             type: object

--- a/docs/gitbook/usage/webhooks.md
+++ b/docs/gitbook/usage/webhooks.md
@@ -124,7 +124,10 @@ Event payload (HTTP POST):
 The event receiver can create alerts based on the received phase 
 (possible values: `Initialized`, `Waiting`, `Progressing`, `Promoting`, `Finalising`, `Succeeded` or `Failed`).
 
-The webhook request can be retried by specifying a positive integer in the `retries` field.
+Options:
+* retries: The webhook request can be retried by specifying a positive integer in the `retries` field. This helps ensure reliability if the webhook fails due to transient network issues.
+
+* disable TLS: Set `disableTLS` to `true` in the webhook spec to bypass TLS verification. This is useful in cases where the target service uses self-signed certificates, or you need to connect to an insecure service for testing purposes.
 
 ## Load Testing
 

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -1135,6 +1135,9 @@ spec:
                           retries:
                             description: Number of retries for this webhook
                             type: number
+                          disableTLS:
+                            description: Disable TLS verification for this webhook
+                            type: boolean
                           metadata:
                             description: Metadata (key-value pairs) for this webhook
                             type: object

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -398,6 +398,10 @@ type CanaryWebhook struct {
 	// Number of retries for this webhook
 	// +optional
 	Retries int `json:"retries,omitempty"`
+
+	// Disable TLS verification for this webhook
+	// +optional
+	DisableTLS bool `json:"disableTLS,omitempty"`
 }
 
 // CanaryWebhookPayload holds the deployment info and metadata sent to webhooks

--- a/pkg/controller/webhook_test.go
+++ b/pkg/controller/webhook_test.go
@@ -289,3 +289,22 @@ func TestCallWebhook_Retries(t *testing.T) {
 		flaggerv1.CanaryPhaseProgressing, hook)
 	require.NoError(t, err)
 }
+
+func TestCallWebhook_DisableTLS(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+	hook := flaggerv1.CanaryWebhook{
+		Name:       "validation",
+		URL:        ts.URL,
+		DisableTLS: true,
+	}
+
+	err := CallWebhook(
+		flaggerv1.Canary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "podinfo", Namespace: corev1.NamespaceDefault}},
+		flaggerv1.CanaryPhaseProgressing, hook)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adding configurable disableTls option for webhooks.

This is useful in cases where the target service uses self-signed certificates, or you need to connect to an insecure service for testing purposes.