### PR TITLE
fix(helm): podinfo fails to create the hpa object

### DIFF
--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 6.1.3
+version: 6.1.4
 appVersion: 6.1.3
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/templates/hpa.yaml
+++ b/charts/podinfo/templates/hpa.yaml
@@ -20,12 +20,16 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.hpa.cpu }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.cpu }}
   {{- end }}
   {{- if .Values.hpa.memory }}
   - type: Resource
     resource:
       name: memory
-      targetAverageValue: {{ .Values.hpa.memory }}
+      target:
+        type: AverageValue 
+        averageValue: {{ .Values.hpa.memory }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
I can't use the podinfo helm chart to deploy. The HPA object need to be updated.

 helm upgrade -i backend flagger/podinfo \
--namespace default \
--set nameOverride=backend \
--set canary.enabled=true
W1111 15:09:04.768137   51420 warnings.go:70] unknown field "spec.metrics[0].resource.targetAverageUtilization"
W1111 15:09:04.768147   51420 warnings.go:70] unknown field "spec.metrics[1].resource.targetAverageValue"
Error: UPGRADE FAILED: failed to create resource: HorizontalPodAutoscaler.autoscaling "backend" is invalid: [spec.metrics[0].resource.target.type: Required value: must specify a metric target type, spec.metrics[0].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[0].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization, spec.metrics[1].resource.target.type: Required value: must specify a metric target type, spec.metrics[1].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[1].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization]