### PR TITLE
Build with Go 1.23

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: fluxcd/flux2/action@main
       - uses: sigstore/cosign-installer@v3.5.0
       - name: Prepare
@@ -125,7 +125,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           version: latest
-          args: release --release-notes=notes.md --rm-dist --skip-validate
+          args: release --release-notes=notes.md --clean --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate SLSA metadata

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 ARG TARGETPLATFORM
 ARG REVISON

--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	CGO_ENABLED=0 go build -a -o ./bin/flagger ./cmd/flagger
 
 tidy:
-	rm -f go.sum; go mod tidy -compat=1.22
+	rm -f go.sum; go mod tidy -compat=1.23
 
 vet:
 	go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/flagger
 
-go 1.22.0
+go 1.23.0
 
 require (
 	cloud.google.com/go/monitoring v1.21.2


### PR DESCRIPTION
Bump Go to 1.23 in go.mod, Dockerfiles and GitHub workflows