### PR TITLE
Preserve HTTPRoute annotations injected by AWS Gateway API

### DIFF
--- a/pkg/router/gateway_api_test.go
+++ b/pkg/router/gateway_api_test.go
@@ -57,6 +57,17 @@ func TestGatewayAPIRouter_Reconcile(t *testing.T) {
 
 	timeout := routeRules[0].Timeouts
 	assert.Equal(t, string(*timeout.Request), canary.Spec.Service.Timeout)
+
+	// assert that http route annotations injected by the networking controller is preserved.
+	httpRoute.Annotations["foo"] = "bar"
+	_, err = router.gatewayAPIClient.GatewayapiV1().HTTPRoutes("default").Update(context.TODO(), httpRoute, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	httpRoute, err = router.gatewayAPIClient.GatewayapiV1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, httpRoute.Annotations["foo"], "bar")
 }
 
 func TestGatewayAPIRouter_Routes(t *testing.T) {

--- a/pkg/router/gateway_api_v1beta1.go
+++ b/pkg/router/gateway_api_v1beta1.go
@@ -23,10 +23,6 @@ import (
 	"slices"
 	"strings"
 
-	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
-	"github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
-	istiov1beta1 "github.com/fluxcd/flagger/pkg/apis/istio/v1beta1"
-	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
@@ -34,6 +30,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+	"github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
+	istiov1beta1 "github.com/fluxcd/flagger/pkg/apis/istio/v1beta1"
+	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 )
 
 var (
@@ -200,16 +201,26 @@ func (gwr *GatewayAPIV1Beta1Router) Reconcile(canary *flaggerv1.Canary) error {
 	}
 
 	if httpRoute != nil {
+		// Preserve the existing annotations added by other controllers such as AWS Gateway API Controller.
+		mergedAnnotations := newMetadata.Annotations
+		for key, val := range httpRoute.Annotations {
+			if _, ok := mergedAnnotations[key]; !ok {
+				mergedAnnotations[key] = val
+			}
+		}
+
+		// Compare the existing HTTPRoute spec and metadata with the desired state.
+		// If there are differences, update the HTTPRoute object.
 		specDiff := cmp.Diff(
 			httpRoute.Spec, httpRouteSpec,
 			ignoreCmpOptions...,
 		)
 		labelsDiff := cmp.Diff(newMetadata.Labels, httpRoute.Labels, cmpopts.EquateEmpty())
-		annotationsDiff := cmp.Diff(newMetadata.Annotations, httpRoute.Annotations, cmpopts.EquateEmpty())
+		annotationsDiff := cmp.Diff(mergedAnnotations, httpRoute.Annotations, cmpopts.EquateEmpty())
 		if (specDiff != "" && httpRoute.Name != "") || labelsDiff != "" || annotationsDiff != "" {
 			hrClone := httpRoute.DeepCopy()
 			hrClone.Spec = httpRouteSpec
-			hrClone.ObjectMeta.Annotations = newMetadata.Annotations
+			hrClone.ObjectMeta.Annotations = mergedAnnotations
 			hrClone.ObjectMeta.Labels = newMetadata.Labels
 			_, err := gwr.gatewayAPIClient.GatewayapiV1beta1().HTTPRoutes(hrNamespace).
 				Update(context.TODO(), hrClone, metav1.UpdateOptions{})

--- a/pkg/router/gateway_api_v1beta1_test.go
+++ b/pkg/router/gateway_api_v1beta1_test.go
@@ -55,6 +55,17 @@ func TestGatewayAPIV1Beta1Router_Reconcile(t *testing.T) {
 	require.Equal(t, len(backendRefs), 2)
 	assert.Equal(t, int32(100), *backendRefs[0].Weight)
 	assert.Equal(t, int32(0), *backendRefs[1].Weight)
+
+	// assert that http route annotations injected by the networking controller is preserved.
+	httpRoute.Annotations["foo"] = "bar"
+	_, err = router.gatewayAPIClient.GatewayapiV1beta1().HTTPRoutes("default").Update(context.TODO(), httpRoute, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	err = router.Reconcile(canary)
+	require.NoError(t, err)
+
+	httpRoute, err = router.gatewayAPIClient.GatewayapiV1beta1().HTTPRoutes("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, httpRoute.Annotations["foo"], "bar")
 }
 
 func TestGatewayAPIV1Beta1Router_Routes(t *testing.T) {


### PR DESCRIPTION
Fix: #1732