### PR TITLE
chore: Improve KubernetesRouter selection based on apiGroup

### DIFF
--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -99,7 +99,7 @@ func (c *Controller) finalize(old interface{}) error {
 	}
 
 	// Revert the Kubernetes service
-	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
+	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.APIVersion, canary.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
 	if err := router.Finalize(canary); err != nil {
 		return fmt.Errorf("failed revert router: %w", err)
 	}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -193,7 +193,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 	}
 
 	// init Kubernetes router
-	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
+	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.APIVersion, cd.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
 
 	// reconcile the canary/primary services
 	if err := kubeRouter.Initialize(cd); err != nil {

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -58,11 +58,11 @@ func NewFactory(kubeConfig *restclient.Config, kubeClient kubernetes.Interface,
 }
 
 // KubernetesRouter returns a KubernetesRouter interface implementation
-func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labelValue string, ports map[string]int32) KubernetesRouter {
-	switch kind {
-	case "Service":
-		return &KubernetesNoopRouter{}
-	default: // Daemonset or Deployment
+func (factory *Factory) KubernetesRouter(apiVersion string, kind string, labelSelector string, labelValue string, ports map[string]int32) KubernetesRouter {
+	group := strings.Split(apiVersion, "/")[0]
+
+	switch {
+	case group == "apps" && (kind == "Deployment" || kind == "DaemonSet"):
 		return &KubernetesDefaultRouter{
 			logger:        factory.logger,
 			flaggerClient: factory.flaggerClient,
@@ -71,6 +71,9 @@ func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labe
 			labelValue:    labelValue,
 			ports:         ports,
 		}
+
+	default:
+		return &KubernetesNoopRouter{}
 	}
 }
 


### PR DESCRIPTION
Allow `.spec.targetRef` to specify custom resources, which typically use mesh routers. Prevent unnecessary resources by strictly handling Deployment and DaemonSet based on apiGroup derived from apiVersion.