### PR TITLE
feat: add option to generate headless services

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -198,6 +198,9 @@ spec:
                     portDiscovery:
                       description: Enable port dicovery
                       type: boolean
+                    headless:
+                      description: Headless if set to true, generates headless Kubernetes services.
+                      type: boolean
                     timeout:
                       description: HTTP or gRPC request timeout
                       type: string

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -198,6 +198,9 @@ spec:
                     portDiscovery:
                       description: Enable port dicovery
                       type: boolean
+                    headless:
+                      description: Headless if set to true, generates headless Kubernetes services.
+                      type: boolean
                     timeout:
                       description: HTTP or gRPC request timeout
                       type: string

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -147,6 +147,7 @@ spec:
     appProtocol: http
     targetPort: 9898
     portDiscovery: true
+    headless: false
 ```
 
 The container port from the target workload should match the `service.port` or `service.targetPort`.
@@ -154,6 +155,7 @@ The `service.name` is optional, defaults to `spec.targetRef.name`.
 The `service.targetPort` can be a container port number or name.
 The `service.portName` is optional (defaults to `http`), if your workload uses gRPC then set the port name to `grpc`.
 The `service.appProtocol` is optional, more details can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol).
+
 
 If port discovery is enabled, Flagger scans the target workload and extracts the containers ports
 excluding the port specified in the canary service and service mesh sidecar ports.
@@ -203,6 +205,9 @@ spec:
 Note that the `apex` annotations are added to both the generated Kubernetes Service and the
 generated service mesh/ingress object. This allows using external-dns with Istio `VirtualServices`
 and `TraefikServices`. Beware of configuration conflicts [here](../faq.md#ExternalDNS).
+
+If you want for the generated Kubernetes ClusterIP services to be [headless](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services),
+then set `service.headless` to true.
 
 Besides port mapping and metadata, the service specification can
 contain URI match and rewrite rules, timeout and retry polices:

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -198,6 +198,9 @@ spec:
                     portDiscovery:
                       description: Enable port dicovery
                       type: boolean
+                    headless:
+                      description: Headless if set to true, generates headless Kubernetes services.
+                      type: boolean
                     timeout:
                       description: HTTP or gRPC request timeout
                       type: string

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -146,6 +146,11 @@ type CanaryService struct {
 	// PortDiscovery adds all container ports to the generated Kubernetes service
 	PortDiscovery bool `json:"portDiscovery"`
 
+	// Headless if set to true, generates headless Kubernetes services.
+	// ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+	// +optional
+	Headless bool `json:"headless,omitempty"`
+
 	// Timeout of the HTTP or gRPC request
 	// +optional
 	Timeout string `json:"timeout,omitempty"`

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -113,6 +113,9 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 			},
 		},
 	}
+	if canary.Spec.Service.Headless {
+		svcSpec.ClusterIP = "None"
+	}
 
 	if v := canary.Spec.Service.AppProtocol; v != "" {
 		svcSpec.Ports[0].AppProtocol = &v

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -34,6 +34,8 @@ import (
 
 func TestServiceRouter_Create(t *testing.T) {
 	mocks := newFixture(nil)
+	mocks.canary.Spec.Service.Headless = true
+
 	router := &KubernetesDefaultRouter{
 		kubeClient:    mocks.kubeClient,
 		flaggerClient: mocks.flaggerClient,
@@ -53,11 +55,13 @@ func TestServiceRouter_Create(t *testing.T) {
 	assert.Equal(t, &appProtocol, canarySvc.Spec.Ports[0].AppProtocol)
 	assert.Equal(t, "http", canarySvc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9898), canarySvc.Spec.Ports[0].Port)
+	assert.Equal(t, "None", canarySvc.Spec.ClusterIP)
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "http", primarySvc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9898), primarySvc.Spec.Ports[0].Port)
+	assert.Equal(t, "None", primarySvc.Spec.ClusterIP)
 }
 
 func TestServiceRouter_Update(t *testing.T) {


### PR DESCRIPTION
Add a new field `.spec.service.headless` which if set to true results in Flagger generating headless Services, i.e. with the Service's `.spec.clusterIP` set to None.

Fixes #1679 