### PR TITLE
Feat: support tracking binaryData in CM and stringData in Secret

### DIFF
--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -60,26 +60,31 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configPrimaryInit, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryInit.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryInit.BinaryData["color_binary"])
 		}
 
 		configPrimaryInitEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryInitEnv.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryInitEnv.BinaryData["color_binary"])
 		}
 
 		configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimary.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimary.BinaryData["color_binary"])
 		}
 
 		configPrimaryEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryEnv.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryEnv.BinaryData["color_binary"])
 		}
 
 		configPrimaryVol, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-vol-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryVol.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryVol.BinaryData["color_binary"])
 		}
 
 		configProjectedName := depPrimary.Spec.Template.Spec.Volumes[2].VolumeSource.Projected.Sources[0].ConfigMap.Name
@@ -136,26 +141,31 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configPrimaryInit, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryInit.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryInit.BinaryData["color_binary"])
 		}
 
 		configPrimaryInitEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-init-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryInitEnv.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryInitEnv.BinaryData["color_binary"])
 		}
 
 		configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimary.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimary.BinaryData["color_binary"])
 		}
 
 		configPrimaryEnv, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryEnv.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryEnv.BinaryData["color_binary"])
 		}
 
 		configPrimaryVol, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-vol-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMap.Data["color"], configPrimaryVol.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryVol.BinaryData["color_binary"])
 		}
 
 		configProjectedName := daePrimary.Spec.Template.Spec.Volumes[2].VolumeSource.Projected.Sources[0].ConfigMap.Name
@@ -164,6 +174,7 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configPrimaryProjected, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-vol-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMapProjected.Data["color"], configPrimaryProjected.Data["color"])
+			assert.Equal(t, configMap.BinaryData["color_binary"], configPrimaryProjected.BinaryData["color_binary"])
 		}
 
 		_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-tracker-enabled", metav1.GetOptions{})
@@ -213,26 +224,31 @@ func TestConfigTracker_Secrets(t *testing.T) {
 		secretPrimaryInit, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInit.Data["apiKey"]))
+			assert.Equal(t, string(secret.StringData["apiKey_string"]), string(secretPrimaryInit.StringData["apiKey_string"]))
 		}
 
 		secretPrimaryInitEnv, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-init-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryInitEnv.Data["apiKey"]))
+			assert.Equal(t, string(secret.StringData["apiKey_string"]), string(secretPrimaryInitEnv.StringData["apiKey_string"]))
 		}
 
 		secretPrimary, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimary.Data["apiKey"]))
+			assert.Equal(t, string(secret.StringData["apiKey_string"]), string(secretPrimary.StringData["apiKey_string"]))
 		}
 
 		secretPrimaryEnv, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-all-env-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryEnv.Data["apiKey"]))
+			assert.Equal(t, string(secret.StringData["apiKey_string"]), string(secretPrimaryEnv.StringData["apiKey_string"]))
 		}
 
 		secretPrimaryVol, err := mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-vol-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secret.Data["apiKey"]), string(secretPrimaryVol.Data["apiKey"]))
+			assert.Equal(t, string(secret.StringData["apiKey_string"]), string(secretPrimaryVol.StringData["apiKey_string"]))
 		}
 
 		secretProjectedName := depPrimary.Spec.Template.Spec.Volumes[2].VolumeSource.Projected.Sources[1].Secret.Name

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -143,6 +143,9 @@ func newDeploymentControllerTestConfigMap() *corev1.ConfigMap {
 		Data: map[string]string{
 			"color": "red",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
+		},
 	}
 }
 
@@ -157,6 +160,9 @@ func newDeploymentControllerTestConfigMapV2() *corev1.ConfigMap {
 			"color":  "blue",
 			"output": "console",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("Ymx1ZAo="),
+		},
 	}
 }
 
@@ -169,6 +175,9 @@ func newDeploymentControllerTestConfigMapInit() *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"color": "red",
+		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
 		},
 	}
 }
@@ -183,6 +192,9 @@ func newDeploymentControllerTestConfigMapInitEnv() *corev1.ConfigMap {
 		Data: map[string]string{
 			"color": "red",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
+		},
 	}
 }
 
@@ -196,6 +208,9 @@ func newDeploymentControllerTestConfigProjected() *corev1.ConfigMap {
 		Data: map[string]string{
 			"color": "red",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
+		},
 	}
 }
 
@@ -208,6 +223,9 @@ func newDeploymentControllerTestConfigMapEnv() *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"color": "red",
+		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
 		},
 	}
 }
@@ -227,6 +245,9 @@ func newDeploymentControllerTestConfigMapTrackerEnabled() *corev1.ConfigMap {
 		Data: map[string]string{
 			"color": "red",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
+		},
 	}
 }
 
@@ -245,6 +266,9 @@ func newDeploymentControllerTestConfigMapTrackerDisabled() *corev1.ConfigMap {
 		Data: map[string]string{
 			"color": "red",
 		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
+		},
 	}
 }
 
@@ -257,6 +281,9 @@ func newDeploymentControllerTestConfigMapVol() *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"color": "red",
+		},
+		BinaryData: map[string][]byte{
+			"color_binary": []byte("cmVkCg=="),
 		},
 	}
 }
@@ -272,6 +299,9 @@ func newDeploymentControllerTestSecret() *corev1.Secret {
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
 		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
+		},
 	}
 }
 
@@ -285,6 +315,9 @@ func newDeploymentControllerTestSecretProjected() *corev1.Secret {
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
+		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
 		},
 	}
 }
@@ -300,6 +333,9 @@ func newDeploymentControllerTestSecretEnv() *corev1.Secret {
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
 		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
+		},
 	}
 }
 
@@ -313,6 +349,9 @@ func newDeploymentControllerTestSecretVol() *corev1.Secret {
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
+		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
 		},
 	}
 }
@@ -333,6 +372,9 @@ func newDeploymentControllerTestSecretTrackerEnabled() *corev1.Secret {
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
 		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
+		},
 	}
 }
 
@@ -352,6 +394,9 @@ func newDeploymentControllerTestSecretTrackerDisabled() *corev1.Secret {
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
 		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
+		},
 	}
 }
 
@@ -366,6 +411,9 @@ func newDeploymentControllerTestSecretInit() *corev1.Secret {
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
 		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
+		},
 	}
 }
 
@@ -379,6 +427,9 @@ func newDeploymentControllerTestSecretInitEnv() *corev1.Secret {
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"apiKey": []byte("test"),
+		},
+		StringData: map[string]string{
+			"apiKey_string": "test",
 		},
 	}
 }


### PR DESCRIPTION
Currently, Flagger does not support creating/tracking/promoting the binaryData in a configmap and the stringData in a secret.
This change tries to support these scenarios.