### PR TITLE
feat: add support for primary backend cookies in session affinity (Gateway API)

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -1155,6 +1155,9 @@ spec:
                         cookieName:
                           description: CookieName is the key that will be used for the session affinity cookie.
                           type: string
+                        primaryCookieName:
+                          description: CookieName is the key that will be used for the session affinity cookie.
+                          type: string
                         maxAge:
                           description: MaxAge indicates the number of seconds until the session affinity cookie will expire.
                           default: 86400

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -1155,6 +1155,9 @@ spec:
                         cookieName:
                           description: CookieName is the key that will be used for the session affinity cookie.
                           type: string
+                        primaryCookieName:
+                          description: CookieName is the key that will be used for the session affinity cookie.
+                          type: string
                         maxAge:
                           description: MaxAge indicates the number of seconds until the session affinity cookie will expire.
                           default: 86400

--- a/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
+++ b/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
@@ -509,6 +509,9 @@ You can load `www.example.com` in your browser and refresh it until you see the 
 All subsequent requests after that will be served by `podinfo:6.0.1` and not `podinfo:6.0.0` because of the session affinity
 configured by Flagger in the HTTPRoute object.
 
+To configure stickiness for the Primary deployment to ensure fair weighted traffic routing, please
+checkout the [deployment strategies docs](../usage/deployment-strategies.md#canary-release-with-session-affinity).
+
 # A/B Testing
 
 Besides weighted routing, Flagger can be configured to route traffic to the canary based on HTTP match conditions. In an A/B testing scenario, you'll be using HTTP headers or cookies to target a certain segment of your users. This is particularly useful for frontend applications that require session affinity.

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -1155,6 +1155,9 @@ spec:
                         cookieName:
                           description: CookieName is the key that will be used for the session affinity cookie.
                           type: string
+                        primaryCookieName:
+                          description: CookieName is the key that will be used for the session affinity cookie.
+                          type: string
                         maxAge:
                           description: MaxAge indicates the number of seconds until the session affinity cookie will expire.
                           default: 86400

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -295,6 +295,9 @@ type SessionAffinity struct {
 	// The default value is 86,400 seconds, i.e. a day.
 	// +optional
 	MaxAge int `json:"maxAge,omitempty"`
+	// PrimaryCookieName is the key that will be used for the primary session affinity cookie.
+	// +optional
+	PrimaryCookieName string `json:"primaryCookieName,omitempty"`
 }
 
 // CanaryMetric holds the reference to metrics used for canary analysis

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -337,6 +337,9 @@ func (c *Controller) verifyCanary(canary *flaggerv1.Canary) error {
 	if err := verifyKnativeCanary(canary); err != nil {
 		return err
 	}
+	if err := verifySessionAffinity(canary); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -372,6 +375,16 @@ func verifyKnativeCanary(canary *flaggerv1.Canary) error {
 	if canary.Spec.TargetRef.IsKnativeService() {
 		if canary.Spec.AutoscalerRef != nil {
 			return fmt.Errorf("can't use autoscaler with Knative Service")
+		}
+	}
+
+	return nil
+}
+
+func verifySessionAffinity(canary *flaggerv1.Canary) error {
+	if canary.Spec.Analysis.SessionAffinity != nil {
+		if canary.Spec.Analysis.SessionAffinity.CookieName == canary.Spec.Analysis.SessionAffinity.PrimaryCookieName {
+			return fmt.Errorf("can't use the same cookie name for both primary and cookie name; please update them to be different")
 		}
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -26,6 +26,7 @@ func TestController_verifyCanary(t *testing.T) {
 						Name:      "upstream",
 						Namespace: "test",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: true,
@@ -42,6 +43,7 @@ func TestController_verifyCanary(t *testing.T) {
 						Name:      "upstream",
 						Namespace: "default",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: false,
@@ -103,6 +105,7 @@ func TestController_verifyCanary(t *testing.T) {
 						Kind: "Deployment",
 						Name: "podinfo",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: true,
@@ -121,6 +124,7 @@ func TestController_verifyCanary(t *testing.T) {
 						APIVersion: "serving.knative.dev/v1",
 						Name:       "podinfo",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: true,
@@ -140,6 +144,7 @@ func TestController_verifyCanary(t *testing.T) {
 						APIVersion: "serving.knative.dev/v1",
 						Name:       "podinfo",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: true,
@@ -158,9 +163,28 @@ func TestController_verifyCanary(t *testing.T) {
 						APIVersion: "serving.knative.dev/v1",
 						Name:       "podinfo",
 					},
+					Analysis: &flaggerv1.CanaryAnalysis{},
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "session affinity with same cookie names should return an error",
+			canary: flaggerv1.Canary{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cd-1",
+					Namespace: "default",
+				},
+				Spec: flaggerv1.CanarySpec{
+					Analysis: &flaggerv1.CanaryAnalysis{
+						SessionAffinity: &flaggerv1.SessionAffinity{
+							CookieName:        "smth",
+							PrimaryCookieName: "smth",
+						},
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 

--- a/test/gatewayapi/test-session-affinity.sh
+++ b/test/gatewayapi/test-session-affinity.sh
@@ -44,7 +44,8 @@ spec:
     maxWeight: 50
     stepWeight: 10
     sessionAffinity:
-      cookieName: flagger-cookie
+      cookieName: canary-flagger-cookie
+      primaryCookieName: primary-flagger-cookie
     metrics:
       - name: error-rate
         templateRef:
@@ -63,7 +64,7 @@ spec:
     webhooks:
       - name: load-test
         type: rollout
-        url: http://flagger-loadtester.test/
+        url: http://localhost:8080
         timeout: 5s
         metadata:
           cmd: "hey -z 2m -q 10 -c 2 -host www.example.com http://gateway-istio.istio-ingress"
@@ -104,7 +105,8 @@ until ${ok}; do
 done
 
 echo '>>> Verifying session affinity'
-if ! URL=http://localhost:8888 HOST=www.example.com VERSION=6.1.0 COOKIE_NAME=flagger-cookie \
+if ! URL=http://localhost:8888 HOST=www.example.com CANARY_VERSION=6.1.0 \
+  CANARY_COOKIE_NAME=canary-flagger-cookie PRIMARY_VERSION=6.0.4 PRIMARY_COOKIE_NAME=primary-flagger-cookie \
     go run ${REPO_ROOT}/test/gatewayapi/verify_session_affinity.go; then
     echo "failed to verify session affinity"
     exit $?


### PR DESCRIPTION
inspired by: https://github.com/fluxcd/flagger/pull/1655/

thanks @tmcg-gusto! 🙇 