### PR TITLE
Release loadtester 0.35.0

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -6,7 +6,7 @@ ARG REVISION
 
 RUN apk --no-cache add alpine-sdk perl curl bash tar
 
-RUN HELM3_VERSION=3.16.3 && \
+RUN HELM3_VERSION=3.17.2 && \
 curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xvz && \
 chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.34.0
-appVersion: 0.34.0
+version: 0.35.0
+appVersion: 0.35.0
 kubeVersion: ">=1.19.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/fluxcd/flagger-loadtester
-  tag: 0.34.0
+  tag: 0.35.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/fluxcd/flagger/pkg/signals"
 )
 
-var VERSION = "0.34.0"
+var VERSION = "0.35.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: ghcr.io/fluxcd/flagger-loadtester:0.34.0
+          image: ghcr.io/fluxcd/flagger-loadtester:0.35.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Includes CVE fixes for loadtester Go dependencies.