### PR TITLE
feat(chart): annotations on ClusterRoleBinding

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- end }}
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
-      {{- end }}                  
+      {{- end }}
       containers:
         - name: flagger
           {{- if .Values.securityContext.enabled }}

--- a/charts/flagger/templates/rbac.yaml
+++ b/charts/flagger/templates/rbac.yaml
@@ -299,6 +299,10 @@ metadata:
     app.kubernetes.io/name: {{ template "flagger.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -129,6 +129,8 @@ rbac:
   create: true
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
+  # rbac.annotations: Set annotations on ClusterRoleBinding
+  annotations: {}
 
 crd:
   # crd.create: `true` if custom resource definitions should be created


### PR DESCRIPTION
### What does this PR do?

Allow chart user to set annotations on `ClusterRoleBinding`.

### Motivation

User can set annotations like this for their linter / security scanner:

```yaml
rbac:
  annotations:
    ignore-check.kube-linter.io/access-to-create-pods: "required by flagger"
    ignore-check.kube-linter.io/access-to-secrets: "required by flagger"
```
