### PR TITLE
loadtester: add pod security context

### DIFF
--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -69,8 +69,10 @@ The following tables lists the configurable parameters of the load tester chart 
 | `istio.tls.enabled`                | Enable TLS in gateway ( TLS secrets should be in namespace )                         | `false`                             |
 | `istio.tls.httpsRedirect`          | Redirect traffic to TLS port                                                         | `false`                             |
 | `podPriorityClassName`             | PriorityClass name for pod priority configuration                                    | ""                                  |
-| `securityContext.enabled`          | Add securityContext to container                                                     | ""                                  |
-| `securityContext.context`          | securityContext to add                                                               | ""                                  |
+| `securityContext.enabled`          | Add securityContext to container                                                     | `false`                             |
+| `SecurityContext.context`          | securityContext to add                                                               | ""                                  |
+| `podSecurityContext.enabled`       | Add securityContext to pod                                                           | `false`                             |
+| `podSecurityContext.context`       | securityContext to add                                                               | ""                                  |
 | `podDisruptionBudget.enabled`      | A PodDisruptionBudget will be created if `true`                                      | `false`                             |
 | `podDisruptionBudget.minAvailable` | The minimal number of available replicas that will be set in the PodDisruptionBudget | `1`                                 |
 

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         appmesh.k8s.aws/ports: "444"
         openservicemesh.io/inbound-port-exclusion-list: "80, 8080"
         {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+          {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.serviceAccountName }}
@@ -39,7 +39,7 @@ spec:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
-{{ toYaml .Values.securityContext.context | indent 12 }}
+            {{- toYaml .Values.securityContext.context | nindent 12 }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -101,4 +101,8 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext.context | nindent 12 }}
     {{- end }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -91,6 +91,12 @@ securityContext:
     runAsUser: 100
     runAsGroup: 101
 
+podSecurityContext:
+  enabled: false
+  context:
+    fsGroup: 101
+    fsGroupChangePolicy: "OnRootMismatch"
+
 podDisruptionBudget:
   enabled: false
   minAvailable: 1


### PR DESCRIPTION
* add pod security context to allow setting `fsGroup` settings
* replace `indent`s with `nindent`s
* update `README.md`