### PR TITLE
fix(chart): fixes a compatibility issue with the Helm Chart and Prometheus v3.0+

### DIFF
--- a/charts/flagger/templates/prometheus.yaml
+++ b/charts/flagger/templates/prometheus.yaml
@@ -233,7 +233,7 @@ spec:
           image: {{ .Values.prometheus.image }}
           imagePullPolicy: IfNotPresent
           args:
-            - '--storage.tsdb.retention={{ .Values.prometheus.retention }}'
+            - '--storage.tsdb.retention.time={{ .Values.prometheus.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
           ports:
             - containerPort: 9090


### PR DESCRIPTION
In the Flagger Helm Chart Prometheus config the storage retention duration is set via this flag --storage.tsdb.retention. This Flag was deprecated in a previous version of Prometheus and removed from Prometheus v3.0+ which means the current Flagger Helm Chart is incompatible with the newer Prometheus versions. 

This flag has now been updated to --storage.tsdb.retention.time which is backwards compatible down to Prometheus v2.51 at least.