### PR TITLE
Added a new field to canary spec to specify unmanaged annotations.

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -909,6 +909,11 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    unmanagedAnnotations:
+                      description: list of annotation keys that should be ignored by Flagger.
+                      type: array
+                      items:
+                        type: string
                 skipAnalysis:
                   description: Skip analysis and promote canary
                   type: boolean

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -223,6 +223,11 @@ type CanaryService struct {
 	// Canary is the metadata to add to the canary service
 	// +optional
 	Canary *CustomMetadata `json:"canary,omitempty"`
+
+	// UnmanagedAnnotations is a list of annotation keys that should be ignored by Flagger.
+	// Flagger will not add, remove or change the value of these annotations.
+	// +optional
+	UnmanagedAnnotations []string `json:"unmanagedAnnotations,omitempty"`
 }
 
 // CanaryAnalysis is used to describe how the analysis should be done

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -452,6 +452,11 @@ func (in *CanaryService) DeepCopyInto(out *CanaryService) {
 		*out = new(CustomMetadata)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.UnmanagedAnnotations != nil {
+		in, out := &in.UnmanagedAnnotations, &out.UnmanagedAnnotations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -213,8 +213,24 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 			if svc.ObjectMeta.Annotations == nil {
 				svc.ObjectMeta.Annotations = make(map[string]string)
 			}
-			if diff := cmp.Diff(filterMetadata(metadata.Annotations), svc.ObjectMeta.Annotations); diff != "" {
-				svcClone.ObjectMeta.Annotations = filterMetadata(metadata.Annotations)
+
+			// Preserve unmanaged annotations
+			unmanagedAnnotations := make(map[string]string)
+			if canary.Spec.Service.UnmanagedAnnotations != nil {
+				for _, key := range canary.Spec.Service.UnmanagedAnnotations {
+					if value, ok := svc.ObjectMeta.Annotations[key]; ok {
+						unmanagedAnnotations[key] = value
+					}
+				}
+			}
+
+			newAnnotations := filterMetadata(metadata.Annotations)
+			for k, v := range unmanagedAnnotations {
+				newAnnotations[k] = v
+			}
+
+			if diff := cmp.Diff(newAnnotations, svc.ObjectMeta.Annotations); diff != "" {
+				svcClone.ObjectMeta.Annotations = newAnnotations
 				updateService = true
 			}
 			if diff := cmp.Diff(metadata.Labels, svc.ObjectMeta.Labels); diff != "" {

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -451,3 +451,47 @@ func TestServiceRouter_ReconcileMetadata(t *testing.T) {
 	assert.Equal(t, "test1", apexSvc.Labels["test"])
 	assert.Equal(t, "podinfo", apexSvc.Labels["app"])
 }
+
+func TestServiceRouter_UnmanagedAnnotations(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &KubernetesDefaultRouter{
+		kubeClient:    mocks.kubeClient,
+		flaggerClient: mocks.flaggerClient,
+		logger:        mocks.logger,
+		labelSelector: "app",
+	}
+
+	mocks.canary.Spec.Service.Apex = &flaggerv1.CustomMetadata{
+		Annotations: map[string]string{"test": "expectedvalue"},
+	}
+	mocks.canary.Spec.Service.UnmanagedAnnotations = []string{"unmanaged"}
+
+	err := router.Initialize(mocks.canary)
+	require.NoError(t, err)
+
+	err = router.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	apexSvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	clone := apexSvc.DeepCopy()
+	clone.Annotations["unmanaged"] = "true"
+	clone.Annotations["test"] = "newvalue"
+	clone.Annotations["removable"] = "true"
+	_, err = mocks.kubeClient.CoreV1().Services("default").Update(context.TODO(), clone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = router.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	apexSvc, err = mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// The result should be that the canary spec annotations should be changed back to configured canary value,
+	// and the unmanaged annotation should remain unchanged.
+	assert.Equal(t, "expectedvalue", apexSvc.Annotations["test"])
+	assert.Equal(t, "true", apexSvc.Annotations["unmanaged"])
+	_, ok := apexSvc.Annotations["removable"]
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Unmanaged annotations are to be ignored by Flagger (i.e. not overwritten / removed upon reconciliation).

See: github.com/fluxcd/flagger/issues/1573