### PR TITLE
Rework selector labels

### DIFF
--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -23,7 +23,7 @@ import (
 type Controller interface {
 	IsPrimaryReady(canary *flaggerv1.Canary) (bool, error)
 	IsCanaryReady(canary *flaggerv1.Canary) (bool, error)
-	GetMetadata(canary *flaggerv1.Canary) (string, string, map[string]int32, error)
+	GetMetadata(canary *flaggerv1.Canary) (map[string]string, string, string, map[string]int32, error)
 	SyncStatus(canary *flaggerv1.Canary, status flaggerv1.CanaryStatus) error
 	SetStatusFailedChecks(canary *flaggerv1.Canary, val int) error
 	SetStatusWeight(canary *flaggerv1.Canary, val int) error

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -19,6 +19,7 @@ package canary
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -120,7 +121,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 			return fmt.Errorf("damonset %s.%s get query error: %v", targetName, cd.Namespace, err)
 		}
 
-		label, labelValue, err := c.getSelectorLabel(canary)
+		matchLabels, label, labelValue, err := c.getSelectorLabel(canary)
 		primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 		if err != nil {
 			return fmt.Errorf("getSelectorLabel failed: %w", err)
@@ -129,6 +130,10 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 		primary, err := c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("daemonset %s.%s get query error: %w", primaryName, cd.Namespace, err)
+		}
+
+		if !maps.Equal(primary.Spec.Selector.MatchLabels, matchLabels) {
+			c.recreatePrimaryDaemonSet(cd, c.includeLabelPrefix)
 		}
 
 		// promote secrets and config maps
@@ -206,24 +211,24 @@ func (c *DaemonSetController) HasTargetChanged(cd *flaggerv1.Canary) (bool, erro
 }
 
 // GetMetadata returns the pod label selector and svc ports
-func (c *DaemonSetController) GetMetadata(cd *flaggerv1.Canary) (string, string, map[string]int32, error) {
+func (c *DaemonSetController) GetMetadata(cd *flaggerv1.Canary) (map[string]string, string, string, map[string]int32, error) {
 	targetName := cd.Spec.TargetRef.Name
 
 	canaryDae, err := c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", nil, fmt.Errorf("daemonset %s.%s get query error: %w", targetName, cd.Namespace, err)
+		return nil, "", "", nil, fmt.Errorf("daemonset %s.%s get query error: %w", targetName, cd.Namespace, err)
 	}
 
-	label, labelValue, err := c.getSelectorLabel(canaryDae)
+	matchLabels, label, labelValue, err := c.getSelectorLabel(canaryDae)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
+		return nil, "", "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
 
 	var ports map[string]int32
 	if cd.Spec.Service.PortDiscovery {
 		ports = getPorts(cd, canaryDae.Spec.Template.Spec.Containers)
 	}
-	return label, labelValue, ports, nil
+	return matchLabels, label, labelValue, ports, nil
 }
 
 func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
@@ -244,7 +249,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 	// Create the labels map but filter unwanted labels
 	labels := includeLabelsByPrefix(canaryDae.Labels, includeLabelPrefix)
 
-	label, labelValue, err := c.getSelectorLabel(canaryDae)
+	matchLabels, label, labelValue, err := c.getSelectorLabel(canaryDae)
 	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
@@ -264,6 +269,8 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 		if err != nil {
 			return fmt.Errorf("makeAnnotations failed: %w", err)
 		}
+
+		matchLabels[label] = primaryLabelValue
 
 		// create primary daemonset
 		primaryDae = &appsv1.DaemonSet{
@@ -285,9 +292,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 				RevisionHistoryLimit: canaryDae.Spec.RevisionHistoryLimit,
 				UpdateStrategy:       canaryDae.Spec.UpdateStrategy,
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						label: primaryLabelValue,
-					},
+					MatchLabels: matchLabels,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -310,18 +315,45 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 	return nil
 }
 
+func (c *DaemonSetController) recreatePrimaryDaemonSet(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
+	targetName := cd.Spec.TargetRef.Name
+	primaryName := fmt.Sprintf("%s-primary", targetName)
+
+	// TODO: Check if primary daemonset is scaled to zero and not receiving any traffic
+
+	if err := c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Delete(context.TODO(), primaryName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("daemonset %s.%s delete error: %w", primaryName, cd.Namespace, err)
+	}
+
+	if err := c.createPrimaryDaemonSet(cd, includeLabelPrefix); err != nil {
+		return fmt.Errorf("createPrimaryDaemonSet failed: %w", err)
+	}
+
+	return nil
+}
+
 // getSelectorLabel returns the selector match label
-func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (string, string, error) {
+func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (map[string]string, string, string, error) {
+	label, labelValue := "", ""
 	for _, l := range c.labels {
 		if _, ok := daemonSet.Spec.Selector.MatchLabels[l]; ok {
-			return l, daemonSet.Spec.Selector.MatchLabels[l], nil
+			label, labelValue = l, daemonSet.Spec.Selector.MatchLabels[l]
 		}
 	}
 
-	return "", "", fmt.Errorf(
-		"daemonset %s.%s spec.selector.matchLabels must contain one of %v'",
-		daemonSet.Name, daemonSet.Namespace, c.labels,
-	)
+	if label == "" {
+		return nil, "", "", fmt.Errorf(
+			"daemonset %s.%s spec.selector.matchLabels must contain one of %v",
+			daemonSet.Name, daemonSet.Namespace, c.labels,
+		)
+	}
+
+	matchLabels := map[string]string{}
+	for key, value := range daemonSet.Spec.Selector.MatchLabels {
+		matchLabels[key] = value
+	}
+
+	return matchLabels, label, labelValue, nil
 }
 
 func (c *DaemonSetController) HaveDependenciesChanged(cd *flaggerv1.Canary) (bool, error) {

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -316,6 +316,7 @@ func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (map
 	for _, l := range c.labels {
 		if _, ok := daemonSet.Spec.Selector.MatchLabels[l]; ok {
 			label, labelValue = l, daemonSet.Spec.Selector.MatchLabels[l]
+			break
 		}
 	}
 

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -127,6 +127,8 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 			return fmt.Errorf("getSelectorLabel failed: %w", err)
 		}
 
+		matchLabels[label] = primaryLabelValue
+
 		primary, err := c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("daemonset %s.%s get query error: %w", primaryName, cd.Namespace, err)

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -138,6 +138,12 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 			c.recreatePrimaryDaemonSet(cd, c.includeLabelPrefix)
 		}
 
+		// Get primary daemonset again, in case it has changed
+		primary, err = c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("daemonset %s.%s get query error: %w", primaryName, cd.Namespace, err)
+		}
+
 		// promote secrets and config maps
 		configRefs, err := c.configTracker.GetTargetConfigs(cd)
 		if err != nil {

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -79,7 +79,9 @@ func TestDaemonSetController_Promote(t *testing.T) {
 	require.NoError(t, err)
 
 	dae2 := newDaemonSetControllerTestPodInfoV2()
-	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Update(context.TODO(), dae2, metav1.UpdateOptions{})
+	err = mocks.kubeClient.AppsV1().DaemonSets("default").Delete(context.TODO(), dae2.ObjectMeta.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Create(context.TODO(), dae2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	config2 := newDaemonSetControllerTestConfigMapV2()
@@ -100,6 +102,12 @@ func TestDaemonSetController_Promote(t *testing.T) {
 	daeSourceLabels := dae2.ObjectMeta.Labels
 	assert.Equal(t, daeSourceLabels["app.kubernetes.io/test-label-1"], daePrimaryLabels["app.kubernetes.io/test-label-1"])
 	assert.Equal(t, "podinfo-primary", daePrimaryLabels["name"])
+
+	daePrimaryMatchLabels := daePrimary.Spec.Selector.MatchLabels
+	daeSourceMatchLabels := dae2.Spec.Selector.MatchLabels
+	assert.Equal(t, len(daeSourceMatchLabels), len(daePrimaryMatchLabels))
+	assert.Equal(t, daeSourceMatchLabels["app.kubernetes.io/test-label-1"], daePrimaryMatchLabels["app.kubernetes.io/test-label-1"])
+	assert.Equal(t, "podinfo-primary", daePrimaryMatchLabels["name"])
 
 	daePrimaryAnnotations := daePrimary.ObjectMeta.Annotations
 	daeSourceAnnotations := dae2.ObjectMeta.Annotations

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -79,9 +79,7 @@ func TestDaemonSetController_Promote(t *testing.T) {
 	require.NoError(t, err)
 
 	dae2 := newDaemonSetControllerTestPodInfoV2()
-	err = mocks.kubeClient.AppsV1().DaemonSets("default").Delete(context.TODO(), dae2.ObjectMeta.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
-	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Create(context.TODO(), dae2, metav1.CreateOptions{})
+	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Update(context.TODO(), dae2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	config2 := newDaemonSetControllerTestConfigMapV2()
@@ -102,12 +100,6 @@ func TestDaemonSetController_Promote(t *testing.T) {
 	daeSourceLabels := dae2.ObjectMeta.Labels
 	assert.Equal(t, daeSourceLabels["app.kubernetes.io/test-label-1"], daePrimaryLabels["app.kubernetes.io/test-label-1"])
 	assert.Equal(t, "podinfo-primary", daePrimaryLabels["name"])
-
-	daePrimaryMatchLabels := daePrimary.Spec.Selector.MatchLabels
-	daeSourceMatchLabels := dae2.Spec.Selector.MatchLabels
-	assert.Equal(t, len(daeSourceMatchLabels), len(daePrimaryMatchLabels))
-	assert.Equal(t, daeSourceMatchLabels["app.kubernetes.io/test-label-1"], daePrimaryMatchLabels["app.kubernetes.io/test-label-1"])
-	assert.Equal(t, "podinfo-primary", daePrimaryMatchLabels["name"])
 
 	daePrimaryAnnotations := daePrimary.ObjectMeta.Annotations
 	daeSourceAnnotations := dae2.ObjectMeta.Annotations

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -72,6 +72,21 @@ func TestDaemonSetController_Sync_InconsistentNaming(t *testing.T) {
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", sourceSelectorValue))
 }
 
+func TestDaemonSetController_Initialize(t *testing.T) {
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
+	_, err := mocks.controller.Initialize(mocks.canary)
+	require.NoError(t, err)
+
+	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	daePrimaryMatchLabels := daePrimary.Spec.Selector.MatchLabels
+	assert.Equal(t, 2, len(daePrimaryMatchLabels))
+	assert.Equal(t, "podinfo-primary", daePrimaryMatchLabels["name"])
+	assert.Equal(t, "test-label-value-1", daePrimaryMatchLabels["test-label-1"])
+}
+
 func TestDaemonSetController_Promote(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -72,6 +72,29 @@ func TestDaemonSetController_Sync_InconsistentNaming(t *testing.T) {
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", sourceSelectorValue))
 }
 
+func TestDaemonSetController_GetMetadata(t *testing.T) {
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
+	_, err := mocks.controller.Initialize(mocks.canary)
+	require.NoError(t, err)
+
+	matchLabels, label, labelValue, _, err := mocks.controller.GetMetadata(mocks.canary)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"name": "podinfo", "test-label-1": "test-label-value-1"}, matchLabels)
+	assert.Equal(t, "name", label)
+	assert.Equal(t, "podinfo", labelValue)
+
+	mocks.controller.labels = []string{"app", "name", "test-label-1"}
+
+	matchLabels, label, labelValue, _, err = mocks.controller.GetMetadata(mocks.canary)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"name": "podinfo", "test-label-1": "test-label-value-1"}, matchLabels)
+	assert.Equal(t, "name", label)
+	assert.Equal(t, "podinfo", labelValue)
+}
+
 func TestDaemonSetController_Initialize(t *testing.T) {
 	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDaemonSetFixture(dc)

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -637,17 +637,28 @@ func newDaemonSetControllerTestPodInfoV2() *appsv1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo",
+			Annotations: map[string]string{
+				"test-annotation-1": "test-annotation-value-1",
+			},
+			Labels: map[string]string{
+				"test-label-1": "test-label-value-1",
+			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "podinfo",
+					"name":         "podinfo",
+					"test-label-1": "test-label-value-1",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": "podinfo",
+						"name":         "podinfo",
+						"test-label-1": "test-label-value-1",
+					},
+					Annotations: map[string]string{
+						"test-annotation-1": "test-annotation-value-1",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -379,7 +379,8 @@ func newDaemonSetControllerTestPodInfo(dc daemonsetConfigs) *appsv1.DaemonSet {
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					dc.label: dc.labelValue,
+					dc.label:       dc.labelValue,
+					"test-label-1": "test-label-value-1",
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -637,28 +637,17 @@ func newDaemonSetControllerTestPodInfoV2() *appsv1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo",
-			Annotations: map[string]string{
-				"test-annotation-1": "test-annotation-value-1",
-			},
-			Labels: map[string]string{
-				"test-label-1": "test-label-value-1",
-			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name":         "podinfo",
-					"test-label-1": "test-label-value-1",
+					"name": "podinfo",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name":         "podinfo",
-						"test-label-1": "test-label-value-1",
-					},
-					Annotations: map[string]string{
-						"test-annotation-1": "test-annotation-value-1",
+						"name": "podinfo",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -79,6 +79,8 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 			return fmt.Errorf("getSelectorLabel failed: %w", err)
 		}
 
+		matchLabels[label] = primaryLabelValue
+
 		primary, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("deployment %s.%s get query error: %w", primaryName, cd.Namespace, err)

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -332,6 +332,7 @@ func (c *DeploymentController) getSelectorLabel(deployment *appsv1.Deployment) (
 	for _, l := range c.labels {
 		if _, ok := deployment.Spec.Selector.MatchLabels[l]; ok {
 			label, labelValue = l, deployment.Spec.Selector.MatchLabels[l]
+			break
 		}
 	}
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -19,6 +19,7 @@ package canary
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,7 +73,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 			return fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
 		}
 
-		label, labelValue, err := c.getSelectorLabel(canary)
+		matchLabels, label, labelValue, err := c.getSelectorLabel(canary)
 		primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 		if err != nil {
 			return fmt.Errorf("getSelectorLabel failed: %w", err)
@@ -81,6 +82,10 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 		primary, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("deployment %s.%s get query error: %w", primaryName, cd.Namespace, err)
+		}
+
+		if !maps.Equal(primary.Spec.Selector.MatchLabels, matchLabels) {
+			c.recreatePrimaryDeployment(cd, c.includeLabelPrefix)
 		}
 
 		// promote secrets and config maps
@@ -219,17 +224,17 @@ func (c *DeploymentController) ScaleFromZero(cd *flaggerv1.Canary) error {
 }
 
 // GetMetadata returns the pod label selector and svc ports
-func (c *DeploymentController) GetMetadata(cd *flaggerv1.Canary) (string, string, map[string]int32, error) {
+func (c *DeploymentController) GetMetadata(cd *flaggerv1.Canary) (map[string]string, string, string, map[string]int32, error) {
 	targetName := cd.Spec.TargetRef.Name
 
 	canaryDep, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", nil, fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
+		return nil, "", "", nil, fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
 	}
 
-	label, labelValue, err := c.getSelectorLabel(canaryDep)
+	matchLabels, label, labelValue, err := c.getSelectorLabel(canaryDep)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
+		return nil, "", "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
 
 	var ports map[string]int32
@@ -237,7 +242,7 @@ func (c *DeploymentController) GetMetadata(cd *flaggerv1.Canary) (string, string
 		ports = getPorts(cd, canaryDep.Spec.Template.Spec.Containers)
 	}
 
-	return label, labelValue, ports, nil
+	return matchLabels, label, labelValue, ports, nil
 }
 func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
 	targetName := cd.Spec.TargetRef.Name
@@ -251,7 +256,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 	// Create the labels map but filter unwanted labels
 	labels := includeLabelsByPrefix(canaryDep.Labels, includeLabelPrefix)
 
-	label, labelValue, err := c.getSelectorLabel(canaryDep)
+	matchLabels, label, labelValue, err := c.getSelectorLabel(canaryDep)
 	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
@@ -277,6 +282,8 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 			replicas = *canaryDep.Spec.Replicas
 		}
 
+		matchLabels[label] = primaryLabelValue
+
 		// create primary deployment
 		primaryDep = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -299,9 +306,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 				Replicas:                int32p(replicas),
 				Strategy:                canaryDep.Spec.Strategy,
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						label: primaryLabelValue,
-					},
+					MatchLabels: matchLabels,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -326,18 +331,45 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 	return nil
 }
 
+func (c *DeploymentController) recreatePrimaryDeployment(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
+	targetName := cd.Spec.TargetRef.Name
+	primaryName := fmt.Sprintf("%s-primary", targetName)
+
+	// TODO: Check if primary deployment is scaled to zero and not receiving any traffic
+
+	if err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Delete(context.TODO(), primaryName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deployment %s.%s delete error: %w", primaryName, cd.Namespace, err)
+	}
+
+	if err := c.createPrimaryDeployment(cd, includeLabelPrefix); err != nil {
+		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
+	}
+
+	return nil
+}
+
 // getSelectorLabel returns the selector match label
-func (c *DeploymentController) getSelectorLabel(deployment *appsv1.Deployment) (string, string, error) {
+func (c *DeploymentController) getSelectorLabel(deployment *appsv1.Deployment) (map[string]string, string, string, error) {
+	label, labelValue := "", ""
 	for _, l := range c.labels {
 		if _, ok := deployment.Spec.Selector.MatchLabels[l]; ok {
-			return l, deployment.Spec.Selector.MatchLabels[l], nil
+			label, labelValue = l, deployment.Spec.Selector.MatchLabels[l]
 		}
 	}
 
-	return "", "", fmt.Errorf(
-		"deployment %s.%s spec.selector.matchLabels must contain one of %v",
-		deployment.Name, deployment.Namespace, c.labels,
-	)
+	if label == "" {
+		return nil, "", "", fmt.Errorf(
+			"deployment %s.%s spec.selector.matchLabels must contain one of %v",
+			deployment.Name, deployment.Namespace, c.labels,
+		)
+	}
+
+	matchLabels := map[string]string{}
+	for key, value := range deployment.Spec.Selector.MatchLabels {
+		matchLabels[key] = value
+	}
+
+	return matchLabels, label, labelValue, nil
 }
 
 func (c *DeploymentController) HaveDependenciesChanged(cd *flaggerv1.Canary) (bool, error) {

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -47,8 +47,18 @@ type DeploymentController struct {
 
 // Initialize creates the primary deployment if it does not exist.
 func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (bool, error) {
-	if err := c.createPrimaryDeployment(cd, c.includeLabelPrefix); err != nil {
-		return true, fmt.Errorf("createPrimaryDeployment failed: %w", err)
+	targetName := cd.Spec.TargetRef.Name
+	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
+
+	canaryDep, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+	if err != nil {
+		return true, fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
+	}
+
+	if _, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{}); errors.IsNotFound(err) {
+		if err := c.createPrimaryDeployment(cd, canaryDep, primaryName, c.includeLabelPrefix); err != nil {
+			return true, fmt.Errorf("createPrimaryDeployment failed: %w", err)
+		}
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
@@ -95,7 +105,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 					targetName,
 					cd.Namespace,
 				)
-			c.recreatePrimaryDeployment(cd, c.includeLabelPrefix)
+			c.recreatePrimaryDeployment(cd, canary, primaryName, c.includeLabelPrefix)
 		}
 
 		// Get primary deployment again, in case it has changes
@@ -260,13 +270,23 @@ func (c *DeploymentController) GetMetadata(cd *flaggerv1.Canary) (map[string]str
 
 	return matchLabels, label, labelValue, ports, nil
 }
-func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
-	targetName := cd.Spec.TargetRef.Name
-	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
-
-	canaryDep, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, canaryDep *appsv1.Deployment, name string, includeLabelPrefix []string) error {
+	// create primary secrets and config maps
+	configRefs, err := c.configTracker.GetTargetConfigs(cd)
 	if err != nil {
-		return fmt.Errorf("deployment %s.%s get query error: %w", targetName, cd.Namespace, err)
+		return fmt.Errorf("GetTargetConfigs failed: %w", err)
+	}
+	if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
+		return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
+	}
+	annotations, err := makeAnnotations(canaryDep.Spec.Template.Annotations)
+	if err != nil {
+		return fmt.Errorf("makeAnnotations failed: %w", err)
+	}
+
+	replicas := int32(1)
+	if canaryDep.Spec.Replicas != nil && *canaryDep.Spec.Replicas > 0 {
+		replicas = *canaryDep.Spec.Replicas
 	}
 
 	// Create the labels map but filter unwanted labels
@@ -278,86 +298,62 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
 
-	primaryDep, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		// create primary secrets and config maps
-		configRefs, err := c.configTracker.GetTargetConfigs(cd)
-		if err != nil {
-			return fmt.Errorf("GetTargetConfigs failed: %w", err)
-		}
-		if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
-			return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
-		}
-		annotations, err := makeAnnotations(canaryDep.Spec.Template.Annotations)
-		if err != nil {
-			return fmt.Errorf("makeAnnotations failed: %w", err)
-		}
+	matchLabels[label] = primaryLabelValue
 
-		replicas := int32(1)
-		if canaryDep.Spec.Replicas != nil && *canaryDep.Spec.Replicas > 0 {
-			replicas = *canaryDep.Spec.Replicas
-		}
-
-		matchLabels[label] = primaryLabelValue
-
-		// create primary deployment
-		primaryDep = &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        primaryName,
-				Namespace:   cd.Namespace,
-				Labels:      makePrimaryLabels(labels, primaryLabelValue, label),
-				Annotations: filterMetadata(canaryDep.Annotations),
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
-						Group:   flaggerv1.SchemeGroupVersion.Group,
-						Version: flaggerv1.SchemeGroupVersion.Version,
-						Kind:    flaggerv1.CanaryKind,
-					}),
-				},
+	// create primary deployment
+	primaryDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   cd.Namespace,
+			Labels:      makePrimaryLabels(labels, primaryLabelValue, label),
+			Annotations: filterMetadata(canaryDep.Annotations),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cd, schema.GroupVersionKind{
+					Group:   flaggerv1.SchemeGroupVersion.Group,
+					Version: flaggerv1.SchemeGroupVersion.Version,
+					Kind:    flaggerv1.CanaryKind,
+				}),
 			},
-			Spec: appsv1.DeploymentSpec{
-				ProgressDeadlineSeconds: canaryDep.Spec.ProgressDeadlineSeconds,
-				MinReadySeconds:         canaryDep.Spec.MinReadySeconds,
-				RevisionHistoryLimit:    canaryDep.Spec.RevisionHistoryLimit,
-				Replicas:                int32p(replicas),
-				Strategy:                canaryDep.Spec.Strategy,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: matchLabels,
-				},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels:      makePrimaryLabels(canaryDep.Spec.Template.Labels, primaryLabelValue, label),
-						Annotations: annotations,
-					},
-					// update spec with the primary secrets and config maps
-					Spec: c.getPrimaryDeploymentTemplateSpec(canaryDep, configRefs),
-				},
+		},
+		Spec: appsv1.DeploymentSpec{
+			ProgressDeadlineSeconds: canaryDep.Spec.ProgressDeadlineSeconds,
+			MinReadySeconds:         canaryDep.Spec.MinReadySeconds,
+			RevisionHistoryLimit:    canaryDep.Spec.RevisionHistoryLimit,
+			Replicas:                int32p(replicas),
+			Strategy:                canaryDep.Spec.Strategy,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
 			},
-		}
-
-		_, err = c.kubeClient.AppsV1().Deployments(cd.Namespace).Create(context.TODO(), primaryDep, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("creating deployment %s.%s failed: %w", primaryDep.Name, cd.Namespace, err)
-		}
-
-		c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
-			Infof("Deployment %s.%s created", primaryDep.GetName(), cd.Namespace)
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      makePrimaryLabels(canaryDep.Spec.Template.Labels, primaryLabelValue, label),
+					Annotations: annotations,
+				},
+				// update spec with the primary secrets and config maps
+				Spec: c.getPrimaryDeploymentTemplateSpec(canaryDep, configRefs),
+			},
+		},
 	}
+
+	_, err = c.kubeClient.AppsV1().Deployments(cd.Namespace).Create(context.TODO(), primaryDep, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating deployment %s.%s failed: %w", primaryDep.Name, cd.Namespace, err)
+	}
+
+	c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).
+		Infof("Deployment %s.%s created", primaryDep.GetName(), cd.Namespace)
 
 	return nil
 }
 
-func (c *DeploymentController) recreatePrimaryDeployment(cd *flaggerv1.Canary, includeLabelPrefix []string) error {
-	targetName := cd.Spec.TargetRef.Name
-	primaryName := fmt.Sprintf("%s-primary", targetName)
+func (c *DeploymentController) recreatePrimaryDeployment(cd *flaggerv1.Canary, canary *appsv1.Deployment, name string, includeLabelPrefix []string) error {
+	// TODO: Make sure primary deployment is not receiving any traffic
 
-	// TODO: Check if primary deployment is scaled to zero and not receiving any traffic
-
-	if err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Delete(context.TODO(), primaryName, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("deployment %s.%s delete error: %w", primaryName, cd.Namespace, err)
+	if err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deployment %s.%s delete error: %w", name, cd.Namespace, err)
 	}
 
-	if err := c.createPrimaryDeployment(cd, includeLabelPrefix); err != nil {
+	if err := c.createPrimaryDeployment(cd, canary, name, includeLabelPrefix); err != nil {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
 	}
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -90,6 +90,12 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 			c.recreatePrimaryDeployment(cd, c.includeLabelPrefix)
 		}
 
+		// Get primary deployment again, in case it has changes
+		primary, err = c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(context.TODO(), primaryName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("deployment %s.%s get query error: %w", primaryName, cd.Namespace, err)
+		}
+
 		// promote secrets and config maps
 		configRefs, err := c.configTracker.GetTargetConfigs(cd)
 		if err != nil {

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -87,6 +87,14 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 		}
 
 		if !maps.Equal(primary.Spec.Selector.MatchLabels, matchLabels) {
+			c.logger.With("canary", fmt.Sprintf(cd.Name, cd.Namespace)).
+				Infof(
+					"Primary deployment %s.%s matchLabels does not match canary deployment %s.%s, recreating...",
+					primaryName,
+					cd.Namespace,
+					targetName,
+					cd.Namespace,
+				)
 			c.recreatePrimaryDeployment(cd, c.includeLabelPrefix)
 		}
 

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -69,6 +69,28 @@ func TestDeploymentController_Sync_InconsistentNaming(t *testing.T) {
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 }
 
+func TestDeploymentController_GetMetadata(t *testing.T) {
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
+	mocks.initializeCanary(t)
+
+	matchLabels, label, labelValue, _, err := mocks.controller.GetMetadata(mocks.canary)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"name": "podinfo", "test-label-1": "test-label-value-1"}, matchLabels)
+	assert.Equal(t, "name", label)
+	assert.Equal(t, "podinfo", labelValue)
+
+	mocks.controller.labels = []string{"app", "name", "test-label-1"}
+
+	matchLabels, label, labelValue, _, err = mocks.controller.GetMetadata(mocks.canary)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"name": "podinfo", "test-label-1": "test-label-value-1"}, matchLabels)
+	assert.Equal(t, "name", label)
+	assert.Equal(t, "podinfo", labelValue)
+}
+
 func TestDeploymentController_Initialize(t *testing.T) {
 	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDeploymentFixture(dc)

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -69,6 +69,20 @@ func TestDeploymentController_Sync_InconsistentNaming(t *testing.T) {
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 }
 
+func TestDeploymentController_Initialize(t *testing.T) {
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
+	mocks.initializeCanary(t)
+
+	depPrimary, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	depPrimaryMatchLabels := depPrimary.Spec.Selector.MatchLabels
+	assert.Equal(t, 2, len(depPrimaryMatchLabels))
+	assert.Equal(t, "podinfo-primary", depPrimaryMatchLabels["name"])
+	assert.Equal(t, "test-label-value-1", depPrimaryMatchLabels["test-label-1"])
+}
+
 func TestDeploymentController_Promote(t *testing.T) {
 	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
 	mocks := newDeploymentFixture(dc)

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -75,7 +75,9 @@ func TestDeploymentController_Promote(t *testing.T) {
 	mocks.initializeCanary(t)
 
 	dep2 := newDeploymentControllerTestV2()
-	_, err := mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
+	err := mocks.kubeClient.AppsV1().Deployments("default").Delete(context.TODO(), dep2.ObjectMeta.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+	_, err = mocks.kubeClient.AppsV1().Deployments("default").Create(context.TODO(), dep2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	config2 := newDeploymentControllerTestConfigMapV2()
@@ -100,6 +102,12 @@ func TestDeploymentController_Promote(t *testing.T) {
 	depPrimaryAnnotations := depPrimary.ObjectMeta.Annotations
 	depSourceAnnotations := dep2.ObjectMeta.Annotations
 	assert.Equal(t, depSourceAnnotations["app.kubernetes.io/test-annotation-1"], depPrimaryAnnotations["app.kubernetes.io/test-annotation-1"])
+
+	depPrimaryMatchLabels := depPrimary.Spec.Selector.MatchLabels
+	depSourceMatchLabels := dep2.Spec.Selector.MatchLabels
+	assert.Equal(t, len(depSourceMatchLabels), len(depPrimaryMatchLabels))
+	assert.Equal(t, depSourceMatchLabels["app.kubernetes.io/test-label-1"], depPrimaryMatchLabels["app.kubernetes.io/test-label-1"])
+	assert.Equal(t, "podinfo-primary", depPrimaryMatchLabels["name"])
 
 	configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 	require.NoError(t, err)

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -75,9 +75,7 @@ func TestDeploymentController_Promote(t *testing.T) {
 	mocks.initializeCanary(t)
 
 	dep2 := newDeploymentControllerTestV2()
-	err := mocks.kubeClient.AppsV1().Deployments("default").Delete(context.TODO(), dep2.ObjectMeta.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
-	_, err = mocks.kubeClient.AppsV1().Deployments("default").Create(context.TODO(), dep2, metav1.CreateOptions{})
+	_, err := mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	config2 := newDeploymentControllerTestConfigMapV2()
@@ -102,12 +100,6 @@ func TestDeploymentController_Promote(t *testing.T) {
 	depPrimaryAnnotations := depPrimary.ObjectMeta.Annotations
 	depSourceAnnotations := dep2.ObjectMeta.Annotations
 	assert.Equal(t, depSourceAnnotations["app.kubernetes.io/test-annotation-1"], depPrimaryAnnotations["app.kubernetes.io/test-annotation-1"])
-
-	depPrimaryMatchLabels := depPrimary.Spec.Selector.MatchLabels
-	depSourceMatchLabels := dep2.Spec.Selector.MatchLabels
-	assert.Equal(t, len(depSourceMatchLabels), len(depPrimaryMatchLabels))
-	assert.Equal(t, depSourceMatchLabels["app.kubernetes.io/test-label-1"], depPrimaryMatchLabels["app.kubernetes.io/test-label-1"])
-	assert.Equal(t, "podinfo-primary", depPrimaryMatchLabels["name"])
 
 	configPrimary, err := mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-env-primary", metav1.GetOptions{})
 	require.NoError(t, err)

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -776,6 +776,7 @@ func newDeploymentControllerTestV2() *appsv1.Deployment {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": "podinfo",
+					"test-label-1": "test-label-value-1",
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -430,7 +430,8 @@ func newDeploymentControllerTest(dc deploymentConfigs) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					dc.label: dc.labelValue,
+					dc.label:       dc.labelValue,
+					"test-label-1": "test-label-value-1",
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -776,7 +776,6 @@ func newDeploymentControllerTestV2() *appsv1.Deployment {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": "podinfo",
-					"test-label-1": "test-label-value-1",
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/pkg/canary/knative_controller.go
+++ b/pkg/canary/knative_controller.go
@@ -54,8 +54,8 @@ func (kc *KnativeController) IsCanaryReady(cd *flaggerv1.Canary) (bool, error) {
 	return true, nil
 }
 
-func (kc *KnativeController) GetMetadata(canary *flaggerv1.Canary) (string, string, map[string]int32, error) {
-	return "", "", make(map[string]int32), nil
+func (kc *KnativeController) GetMetadata(canary *flaggerv1.Canary) (map[string]string, string, string, map[string]int32, error) {
+	return nil, "", "", make(map[string]int32), nil
 }
 
 // SyncStatus encodes list of revisions and updates the canary status

--- a/pkg/canary/service_controller.go
+++ b/pkg/canary/service_controller.go
@@ -61,8 +61,8 @@ func (c *ServiceController) SetStatusPhase(cd *flaggerv1.Canary, phase flaggerv1
 }
 
 // GetMetadata returns the pod label selector, label value and svc ports
-func (c *ServiceController) GetMetadata(_ *flaggerv1.Canary) (string, string, map[string]int32, error) {
-	return "", "", nil, nil
+func (c *ServiceController) GetMetadata(_ *flaggerv1.Canary) (map[string]string, string, string, map[string]int32, error) {
+	return nil, "", "", nil, nil
 }
 
 // Initialize creates or updates the primary and canary services to prepare for the canary release process targeted on the K8s service

--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -93,13 +93,13 @@ func (c *Controller) finalize(old interface{}) error {
 		return fmt.Errorf("canary not ready during finalizing: %w", err)
 	}
 
-	labelSelector, labelValue, ports, err := canaryController.GetMetadata(canary)
+	matchLabels, labelSelector, labelValue, ports, err := canaryController.GetMetadata(canary)
 	if err != nil {
 		return fmt.Errorf("failed to get metadata for router finalizing: %w", err)
 	}
 
 	// Revert the Kubernetes service
-	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
+	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.Kind, matchLabels, labelSelector, labelValue, ports)
 	if err := router.Finalize(canary); err != nil {
 		return fmt.Errorf("failed revert router: %w", err)
 	}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -181,7 +181,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 	// init controller based on target kind
 	canaryController := c.canaryFactory.Controller(cd.Spec.TargetRef)
 
-	labelSelector, labelValue, ports, err := canaryController.GetMetadata(cd)
+	matchLabels, labelSelector, labelValue, ports, err := canaryController.GetMetadata(cd)
 	if err != nil {
 		c.recordEventWarningf(cd, "%v", err)
 		return
@@ -193,7 +193,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 	}
 
 	// init Kubernetes router
-	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
+	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.Kind, matchLabels, labelSelector, labelValue, ports)
 
 	// reconcile the canary/primary services
 	if err := kubeRouter.Initialize(cd); err != nil {

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -62,7 +62,7 @@ func NewFactory(kubeConfig *restclient.Config, kubeClient kubernetes.Interface,
 }
 
 // KubernetesRouter returns a KubernetesRouter interface implementation
-func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labelValue string, ports map[string]int32) KubernetesRouter {
+func (factory *Factory) KubernetesRouter(kind string, matchLabels map[string]string, labelSelector string, labelValue string, ports map[string]int32) KubernetesRouter {
 	switch kind {
 	case "Service":
 		return &KubernetesNoopRouter{}
@@ -71,6 +71,7 @@ func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labe
 			logger:        factory.logger,
 			flaggerClient: factory.flaggerClient,
 			kubeClient:    factory.kubeClient,
+			matchLabels:   matchLabels,
 			labelSelector: labelSelector,
 			labelValue:    labelValue,
 			ports:         ports,

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -40,6 +40,7 @@ type KubernetesDefaultRouter struct {
 	kubeClient    kubernetes.Interface
 	flaggerClient clientset.Interface
 	logger        *zap.SugaredLogger
+	matchLabels   map[string]string
 	labelSelector string
 	labelValue    string
 	ports         map[string]int32
@@ -100,10 +101,16 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 		targetPort = canary.Spec.Service.TargetPort
 	}
 
+	selector := map[string]string{}
+	for k, v := range c.matchLabels {
+		selector[k] = v
+	}
+	selector[c.labelSelector] = podSelector
+
 	// set pod selector and apex port
 	svcSpec := corev1.ServiceSpec{
 		Type:     corev1.ServiceTypeClusterIP,
-		Selector: map[string]string{c.labelSelector: podSelector},
+		Selector: selector,
 		Ports: []corev1.ServicePort{
 			{
 				Name:       portName,

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -40,6 +40,12 @@ func TestServiceRouter_Create(t *testing.T) {
 		kubeClient:    mocks.kubeClient,
 		flaggerClient: mocks.flaggerClient,
 		logger:        mocks.logger,
+		matchLabels: map[string]string{
+			"name":         "podinfo",
+			"test-label-1": "test-label-value-1",
+		},
+		labelSelector: "name",
+		labelValue:    "podinfo",
 	}
 	appProtocol := "http"
 
@@ -52,6 +58,9 @@ func TestServiceRouter_Create(t *testing.T) {
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
 
+	assert.Equal(t, 2, len(canarySvc.Spec.Selector))
+	assert.Equal(t, "podinfo", canarySvc.Spec.Selector["name"])
+	assert.Equal(t, "test-label-value-1", canarySvc.Spec.Selector["test-label-1"])
 	assert.Equal(t, &appProtocol, canarySvc.Spec.Ports[0].AppProtocol)
 	assert.Equal(t, "http", canarySvc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9898), canarySvc.Spec.Ports[0].Port)
@@ -59,6 +68,10 @@ func TestServiceRouter_Create(t *testing.T) {
 
 	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(primarySvc.Spec.Selector))
+	assert.Equal(t, "podinfo-primary", primarySvc.Spec.Selector["name"])
+	assert.Equal(t, "test-label-value-1", primarySvc.Spec.Selector["test-label-1"])
 	assert.Equal(t, "http", primarySvc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9898), primarySvc.Spec.Ports[0].Port)
 	assert.Equal(t, "None", primarySvc.Spec.ClusterIP)


### PR DESCRIPTION
Addresses #1312, #1257, #1115

Retains all `matchLabels` in the primary `Deployment` or `DaemonSet`, instead of picking the first one that matches the `-selector-labels`.

Still appends `-primary` to the value of the first label that matches `-selector-labels`. This ensures that the canary and primary have a unique set of selector labels.

`Service` selector also uses the full set of `matchLabels` and overrides the value of the first matching `-selector-labels` to route to canary or primary.

Does not recreate the primary `Deployment` or `DaemonSet` if the `matchLabels` of the existing object are not equal.

Does update the `Service` selector labels to match the new behavior.