### PR TITLE
Fix `apisix` E2E test

### DIFF
--- a/test/apisix/install.sh
+++ b/test/apisix/install.sh
@@ -15,6 +15,7 @@ helm repo add apisix https://charts.apiseven.com
 
 helm upgrade -i apisix apisix/apisix --version=${APISIX_CHART_VERSION} \
 --namespace apisix \
+--set etcd.image.repository=bitnamilegacy/etcd \
 --set apisix.podAnnotations."prometheus\.io/scrape"=true \
 --set apisix.podAnnotations."prometheus\.io/port"=9091 \
 --set apisix.podAnnotations."prometheus\.io/path"=/apisix/prometheus/metrics \


### PR DESCRIPTION
`apisix` Helm chart has dependency on `etcd` chart which uses a pinned Bitnami image. These became unavailable on August 28, 2025: https://github.com/bitnami/containers/issues/83267

The image is still available in the `bitnamilegacy` repository.