### PR TITLE
Add support for setting traffic distribution

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -191,11 +191,18 @@ spec:
                     appProtocol:
                       description: Application protocol of the port
                       type: string
+                    trafficDistribution:
+                      description: Traffic distribution of the service
+                      type: string
+                      enum:
+                        - PreferClose
+                        - PreferSameZone
+                        - PreferSameNode
                     targetPort:
                       description: Container target port name
                       x-kubernetes-int-or-string: true
                     portDiscovery:
-                      description: Enable port dicovery
+                      description: Enable port discovery
                       type: boolean
                     headless:
                       description: Headless if set to true, generates headless Kubernetes services.

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -191,11 +191,18 @@ spec:
                     appProtocol:
                       description: Application protocol of the port
                       type: string
+                    trafficDistribution:
+                      description: Traffic distribution of the service
+                      type: string
+                      enum:
+                        - PreferClose
+                        - PreferSameZone
+                        - PreferSameNode
                     targetPort:
                       description: Container target port name
                       x-kubernetes-int-or-string: true
                     portDiscovery:
-                      description: Enable port dicovery
+                      description: Enable port discovery
                       type: boolean
                     headless:
                       description: Headless if set to true, generates headless Kubernetes services.

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -148,6 +148,7 @@ spec:
     targetPort: 9898
     portDiscovery: true
     headless: false
+    trafficDistribution: PreferClose
 ```
 
 The container port from the target workload should match the `service.port` or `service.targetPort`.
@@ -155,7 +156,7 @@ The `service.name` is optional, defaults to `spec.targetRef.name`.
 The `service.targetPort` can be a container port number or name.
 The `service.portName` is optional (defaults to `http`), if your workload uses gRPC then set the port name to `grpc`.
 The `service.appProtocol` is optional, more details can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol).
-
+The `service.trafficDistribution` is optional, more details can be found [here](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution).
 
 If port discovery is enabled, Flagger scans the target workload and extracts the containers ports
 excluding the port specified in the canary service and service mesh sidecar ports.

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -191,11 +191,18 @@ spec:
                     appProtocol:
                       description: Application protocol of the port
                       type: string
+                    trafficDistribution:
+                      description: Traffic distribution of the service
+                      type: string
+                      enum:
+                        - PreferClose
+                        - PreferSameZone
+                        - PreferSameNode
                     targetPort:
                       description: Container target port name
                       x-kubernetes-int-or-string: true
                     portDiscovery:
-                      description: Enable port dicovery
+                      description: Enable port discovery
                       type: boolean
                     headless:
                       description: Headless if set to true, generates headless Kubernetes services.

--- a/pkg/apis/flagger/v1beta1/canary.go
+++ b/pkg/apis/flagger/v1beta1/canary.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
-	istiov1beta1 "github.com/fluxcd/flagger/pkg/apis/istio/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/fluxcd/flagger/pkg/apis/gatewayapi/v1beta1"
+	istiov1beta1 "github.com/fluxcd/flagger/pkg/apis/istio/v1beta1"
 )
 
 const (
@@ -149,6 +150,11 @@ type CanaryService struct {
 	// https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
 	// +optional
 	AppProtocol string `json:"appProtocol,omitempty"`
+
+	// TrafficDistribution of the service
+	// https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+	// +optional
+	TrafficDistribution string `json:"trafficDistribution,omitempty"`
 
 	// PortDiscovery adds all container ports to the generated Kubernetes service
 	PortDiscovery bool `json:"portDiscovery"`

--- a/pkg/canary/service_controller.go
+++ b/pkg/canary/service_controller.go
@@ -165,6 +165,11 @@ func buildService(canary *flaggerv1.Canary, name string, src *corev1.Service) *c
 		//   Operation cannot be fulfilled on services "mysvc-canary": the object has been modified; please apply your changes to the latest version and try again
 		delete(svc.ObjectMeta.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	}
+
+	if v := canary.Spec.Service.TrafficDistribution; v != "" {
+		svc.Spec.TrafficDistribution = &v
+	}
+
 	return svc
 }
 

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -121,6 +121,10 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 		svcSpec.Ports[0].AppProtocol = &v
 	}
 
+	if v := canary.Spec.Service.TrafficDistribution; v != "" {
+		svcSpec.TrafficDistribution = &v
+	}
+
 	// set additional ports
 	for n, p := range c.ports {
 		cp := corev1.ServicePort{


### PR DESCRIPTION
This PR adds the optional field `.spec.service.trafficDistribution` to the Canary API. 

Traffic distribution docs: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution

Closes: https://github.com/fluxcd/flagger/issues/1833

