### PR TITLE
Release loadtester 0.36.0

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -6,11 +6,11 @@ ARG REVISION
 
 RUN apk --no-cache add alpine-sdk perl curl bash tar
 
-RUN HELM3_VERSION=3.17.2 && \
+RUN HELM3_VERSION=3.19.0 && \
 curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xvz && \
 chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm
 
-RUN KUBECTL_VERSION=v1.31.3 &&  \
+RUN KUBECTL_VERSION=v1.34.1 &&  \
 curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
 chmod +x kubectl && mv kubectl /usr/local/bin/kubectl
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.35.0
-appVersion: 0.35.0
+version: 0.36.0
+appVersion: 0.36.0
 kubeVersion: ">=1.19.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/fluxcd/flagger-loadtester
-  tag: 0.35.0
+  tag: 0.36.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/fluxcd/flagger/pkg/signals"
 )
 
-var VERSION = "0.35.0"
+var VERSION = "0.36.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: ghcr.io/fluxcd/flagger-loadtester:0.35.0
+          image: ghcr.io/fluxcd/flagger-loadtester:0.36.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/controller/events_test.go
+++ b/pkg/controller/events_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (
@@ -7,10 +23,11 @@ import (
 	"sync"
 	"testing"
 
-	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 )
 
 func TestWebhooks(t *testing.T) {


### PR DESCRIPTION
Includes CVE fixes in Go dependencies and tools updates (Helm v3.18 and Kubectl v1.34). 