### PR TITLE
Release Flagger 1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.42.0
+
+**Release date:** 2025-10-16
+
+This release comes with enhancements to Gateway API support, new metrics capabilities, and various bug fixes.
+
+Flagger now supports Gateway API v1.4.0 and adds CORS policy configuration for Gateway API HTTPRoutes.
+For more information, please see the [Gateway API tutorial](https://docs.flagger.app/main/tutorials/gatewayapi-progressive-delivery#customising-the-httproute).
+
+Session affinity support has been enhanced with [cookie attributes](https://docs.flagger.app/main/usage/deployment-strategies#configuring-additional-cookie-attributes)
+configuration for better control over session management.
+
+A new `.spec.service.unmanagedMetadata` field has been added to the Canary API to allow 3rd-party
+controllers to set labels and annotations on the Kubernetes Services created by Flagger.
+
+When running Flagger on Kubernetes 1.33 or later, users can now specify the traffic distribution
+using the new `.spec.service.trafficDistribution` Canary field. Depending on the Kubernetes version
+the traffic distribution can be set to `PreferClose`, `PreferSameZone` or `PreferSameNode`.
+See the [Kubernetes Service docs](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) for more details.
+
+This release is built with Go 1.25. The Kubernetes dependencies have been updated to 1.34,
+and the Traefik API has been migrated from `traefik.containo.us` to `traefik.io`.
+
+#### Improvements
+- Update Gateway API to v1.4.0
+  [#1842](https://github.com/fluxcd/flagger/pull/1842)
+- Add support for CORS policy to Gateway API
+  [#1843](https://github.com/fluxcd/flagger/pull/1843)
+- Add support for setting traffic distribution
+  [#1844](https://github.com/fluxcd/flagger/pull/1844)
+- Add count metrics for canary successes and failures
+  [#1812](https://github.com/fluxcd/flagger/pull/1812)
+- Add support for cookie attributes in session affinity
+  [#1826](https://github.com/fluxcd/flagger/pull/1826)
+- Add `unmanagedMetadata` to canary service specification
+  [#1823](https://github.com/fluxcd/flagger/pull/1823)
+- Update dependencies to Kubernetes 1.34
+  [#1832](https://github.com/fluxcd/flagger/pull/1832)
+- Build with Go 1.25
+  [#1832](https://github.com/fluxcd/flagger/pull/1832)
+- Update Traefik API from traefik.containo.us to traefik.io
+  [#1835](https://github.com/fluxcd/flagger/pull/1835)
+- Update GitOps install docs to latest Flux APIs
+  [#1845](https://github.com/fluxcd/flagger/pull/1845)
+- loadtester: add pod security context
+  [#1803](https://github.com/fluxcd/flagger/pull/1803)
+- Release loadtester 0.36.0
+  [#1846](https://github.com/fluxcd/flagger/pull/1846)
+
+#### Fixes
+- Fix: Gateway router should wait for accepted condition
+  [#1791](https://github.com/fluxcd/flagger/pull/1791)
+- Fix: Send succeeded webhooks with correct phase
+  [#1792](https://github.com/fluxcd/flagger/pull/1792)
+- Fix: Honor event webhook timeout
+  [#1797](https://github.com/fluxcd/flagger/pull/1797)
+- Fix: Default namespace for cross-namespace ref validation
+  [#1828](https://github.com/fluxcd/flagger/pull/1828)
+- Fix: APISIX E2E test
+  [#1831](https://github.com/fluxcd/flagger/pull/1831)
+- Fix: Correct typo in AutoscalerReference type name
+  [#1739](https://github.com/fluxcd/flagger/pull/1739)
+
 ## 1.41.0
 
 **Release date:** 2025-04-02

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: ghcr.io/fluxcd/flagger:1.41.0
+        image: ghcr.io/fluxcd/flagger:1.42.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 1.41.0
-appVersion: 1.41.0
+version: 1.42.0
+appVersion: 1.42.0
 kubeVersion: ">=1.19.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: ghcr.io/fluxcd/flagger
-  tag: 1.41.0
+  tag: 1.42.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
+++ b/docs/gitbook/tutorials/gatewayapi-progressive-delivery.md
@@ -2,7 +2,7 @@
 
 This guide shows you how to use [Gateway API](https://gateway-api.sigs.k8s.io/) and Flagger to automate canary deployments and A/B testing.
 
-![Flagger Canary Stages](https://raw.githubusercontent.com/fluxcd/flagger/main/docs/diagrams/flagger-gatewayapi-canary.png)
+![Flagger Gateway API Integration](https://raw.githubusercontent.com/fluxcd/flagger/main/docs/diagrams/flagger-gatewayapi-canary.png)
 
 ## Prerequisites
 
@@ -285,6 +285,11 @@ kubectl port-forward -n istio-ingress svc/gateway-istio 8080:80
 Now you can access podinfo via `curl -H "Host: www.example.com" localhost:8080`.
 
 ## Automated canary promotion
+
+With the application bootstrapped, Flagger will continuously monitor the deployment for changes.
+When a new revision is detected, Flagger will start a canary analysis and gradually shift traffic to the new version.
+
+![Flagger Canary Stages](https://raw.githubusercontent.com/fluxcd/flagger/main/docs/diagrams/flagger-canary-steps.png)
 
 Trigger a canary deployment by updating the container image:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
   - name: ghcr.io/fluxcd/flagger
     newName: ghcr.io/fluxcd/flagger
-    newTag: 1.41.0
+    newTag: 1.42.0

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -185,7 +185,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 		err = n.Post(canary.Name, canary.Namespace, message, fields, string(severity))
 		if err != nil {
 			c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
-				Errorf("alert provider $s.%s send error: %v", alert.ProviderRef.Name, providerNamespace, err)
+				Errorf("alert provider %s.%s send error: %v", alert.ProviderRef.Name, providerNamespace, err)
 		}
 
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package version
 
-var VERSION = "1.41.0"
+var VERSION = "1.42.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This release comes with enhancements to Gateway API support, new metrics capabilities, and various bug fixes.

Flagger now supports Gateway API v1.4.0 and adds CORS policy configuration for Gateway API HTTPRoutes.
For more information, please see the [Gateway API tutorial](https://docs.flagger.app/main/tutorials/gatewayapi-progressive-delivery#customising-the-httproute).

Session affinity support has been enhanced with [cookie attributes](https://docs.flagger.app/main/usage/deployment-strategies#configuring-additional-cookie-attributes) configuration for better control over session management.

A new `.spec.service.unmanagedMetadata` field has been added to the Canary API to allow 3rd-party controllers to set labels and annotations on the Kubernetes Services created by Flagger.

When running Flagger on Kubernetes 1.33 or later, users can now specify the traffic distribution using the new `.spec.service.trafficDistribution` Canary field. Depending on the Kubernetes version the traffic distribution can be set to `PreferClose`, `PreferSameZone` or `PreferSameNode`. See the [Kubernetes Service docs](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) for more details.

This release is built with Go 1.25. The Kubernetes dependencies have been updated to 1.34, and the Traefik API has been migrated from `traefik.containo.us` to `traefik.io`.