### PR TITLE
Fix bug where CanaryWeight is reset to 0 during CanaryPhasePromoting

### DIFF
--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -158,7 +158,7 @@ func setStatusPhase(flaggerClient clientset.Interface, cd *flaggerv1.Canary, pha
 		cdCopy.Status.Phase = phase
 		cdCopy.Status.LastTransitionTime = metav1.Now()
 
-		if phase != flaggerv1.CanaryPhaseProgressing && phase != flaggerv1.CanaryPhaseWaiting {
+		if phase != flaggerv1.CanaryPhaseProgressing && phase != flaggerv1.CanaryPhaseWaiting && phase != flaggerv1.CanaryPhasePromoting {
 			cdCopy.Status.CanaryWeight = 0
 			cdCopy.Status.Iterations = 0
 			if phase == flaggerv1.CanaryPhaseWaitingPromotion {

--- a/pkg/controller/scheduler_deployment_test.go
+++ b/pkg/controller/scheduler_deployment_test.go
@@ -179,27 +179,33 @@ func TestScheduler_DeploymentAnalysisPhases(t *testing.T) {
 	// detect changes
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhaseProgressing))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 0))
 	mocks.makeCanaryReady(t)
 
 	// progressing
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhaseProgressing))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 100))
 
 	// start promotion
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhasePromoting))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 100))
 
 	// end promotion
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhasePromoting))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 50))
 
 	// finalising
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhaseFinalising))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 0))
 
 	// succeeded
 	mocks.ctrl.advanceCanary("podinfo", "default")
 	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhaseSucceeded))
+	require.NoError(t, assertCanaryWeight(mocks.flaggerClient, "podinfo", 0))
 }
 
 func TestScheduler_DeploymentBlueGreenAnalysisPhases(t *testing.T) {

--- a/pkg/controller/scheduler_test.go
+++ b/pkg/controller/scheduler_test.go
@@ -60,6 +60,19 @@ func assertPhase(flaggerClient clientset.Interface, canary string, phase flagger
 	return nil
 }
 
+func assertCanaryWeight(flaggerClient clientset.Interface, canary string, canaryWeight int) error {
+	c, err := flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), canary, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if c.Status.CanaryWeight != canaryWeight {
+		return fmt.Errorf("got canary weight %d wanted %d", c.Status.CanaryWeight, canaryWeight)
+	}
+
+	return nil
+}
+
 func alwaysReady() bool {
 	return true
 }


### PR DESCRIPTION
This is just a display issue in the status, that can cause some confusion.