### PR TITLE
Remove metrics metric after a canary is deleted

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -298,7 +298,7 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Clean the metrics if marked for deletion
 	if cd.ObjectMeta.DeletionTimestamp != nil {
-		c.recorder.DeleteStatus(cd)
+		c.recorder.DeleteMetrics(cd)
 	}
 
 	// set status condition for new canaries


### PR DESCRIPTION
TL;DR;
Fixes https://github.com/fluxcd/flagger/issues/1029
plus removes some more unneeded metrics


When deleting a canary, its status metric is not updated. Having two canaries deployed, both initialized, metrics endpoint exposes
```
# HELP flagger_canary_status Last canary analysis result
# TYPE flagger_canary_status gauge
flagger_canary_status{name="canary1",namespace="foo"} 1
flagger_canary_status{name="canary2",namespace="foo"} 1
# HELP flagger_canary_total Total number of canary object
# TYPE flagger_canary_total gauge
flagger_canary_total{namespace="foo"} 2
```

After deleting one, the metrics are updated to
```
# HELP flagger_canary_status Last canary analysis result
# TYPE flagger_canary_status gauge
flagger_canary_status{name="canary1",namespace="foo"} 1   # <--- this one was deleted, but not reflected here
flagger_canary_status{name="canary2",namespace="foo"} 1
# HELP flagger_canary_total Total number of canary object
# TYPE flagger_canary_total gauge
flagger_canary_total{namespace="foo"} 1
```

Deleting the metric feels more appropriate than marking it as deleted, as otherwise the amount of timeseries can grow a lot and, if it's deleted, it means that it's probably not needed anymore
