### PR TITLE
fix: datadog metrics should provide http status code on error if non-2xx response

### DIFF
--- a/pkg/metrics/providers/datadog.go
+++ b/pkg/metrics/providers/datadog.go
@@ -131,7 +131,7 @@ func (p *DatadogProvider) RunQuery(query string) (float64, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("error response: %s: %w", string(b), err)
+		return 0, fmt.Errorf("error response: %s: %s", string(b), r.Status)
 	}
 
 	var res datadogResponse


### PR DESCRIPTION
currently the log line exposes the error, however that's always going to be nil based on the check just above it.  This provides better visibility into the failure reason

Previously:
```
frontend-errors-beta: error response: : %!w(<nil>)
```

Now:
```
frontend-errors-beta: error response: : 500 InternalServerError
```