### PR TITLE
Multi-Namespace scoping and NerdGraph Provider

### DIFF
--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -503,4 +503,3 @@ func verifyKubernetesVersion(kubeClient kubernetes.Interface, logger *zap.Sugare
 
 	logger.Infof("Connected to Kubernetes API %s", ver)
 }
-

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/fluxcd/flagger/pkg/canary"
 	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 	informers "github.com/fluxcd/flagger/pkg/client/informers/externalversions"
+	flaggerinformers "github.com/fluxcd/flagger/pkg/client/informers/externalversions/flagger/v1beta1"
 	"github.com/fluxcd/flagger/pkg/controller"
 	"github.com/fluxcd/flagger/pkg/logger"
 	"github.com/fluxcd/flagger/pkg/metrics/observers"
@@ -111,7 +112,7 @@ func init() {
 	flag.IntVar(&threadiness, "threadiness", 2, "Worker concurrency.")
 	flag.BoolVar(&zapReplaceGlobals, "zap-replace-globals", false, "Whether to change the logging level of the global zap logger.")
 	flag.StringVar(&zapEncoding, "zap-encoding", "json", "Zap logger encoding.")
-	flag.StringVar(&namespace, "namespace", "", "Namespace that flagger would watch canary object.")
+	flag.StringVar(&namespace, "namespace", "", "Comma-separated list of namespaces to watch. If empty, watches all namespaces.")
 	flag.StringVar(&meshProvider, "mesh-provider", "istio", "Service mesh provider, can be istio, linkerd, appmesh, contour, knative, gloo, nginx, skipper, traefik, apisix, osm or kuma.")
 	flag.StringVar(&selectorLabels, "selector-labels", "app,name,app.kubernetes.io/name", "List of pod labels that Flagger uses to create pod selectors.")
 	flag.StringVar(&ingressAnnotationsPrefix, "ingress-annotations-prefix", "nginx.ingress.kubernetes.io", "Annotations prefix for NGINX ingresses.")
@@ -296,34 +297,88 @@ func main() {
 	}
 }
 
+func parseNamespaces(namespaceFlag string) []string {
+	if namespaceFlag == "" {
+		return []string{}
+	}
+	namespaces := strings.Split(namespaceFlag, ",")
+	result := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		trimmed := strings.TrimSpace(ns)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
 func startInformers(flaggerClient clientset.Interface, logger *zap.SugaredLogger, stopCh <-chan struct{}) controller.Informers {
-	flaggerInformerFactory := informers.NewSharedInformerFactoryWithOptions(flaggerClient, time.Second*30, informers.WithNamespace(namespace))
+	namespaces := parseNamespaces(namespace)
+	canaryInformers := make(map[string]flaggerinformers.CanaryInformer)
+	metricInformers := make(map[string]flaggerinformers.MetricTemplateInformer)
+	alertInformers := make(map[string]flaggerinformers.AlertProviderInformer)
 
-	logger.Info("Waiting for canary informer cache to sync")
-	canaryInformer := flaggerInformerFactory.Flagger().V1beta1().Canaries()
-	go canaryInformer.Informer().Run(stopCh)
-	if ok := cache.WaitForNamedCacheSync("flagger", stopCh, canaryInformer.Informer().HasSynced); !ok {
-		logger.Fatalf("failed to wait for cache to sync")
+	// this slice will hold all the sync functions we need to wait for
+	var allSyncs []cache.InformerSynced
+
+	if len(namespaces) == 0 {
+		// watch all namespaces
+		logger.Info("Watching all namespaces")
+		factory := informers.NewSharedInformerFactoryWithOptions(flaggerClient, time.Second*30, informers.WithNamespace(""))
+
+		canary := factory.Flagger().V1beta1().Canaries()
+		canaryInformers[""] = canary // keyed to "" because it's watching all namespaces
+		allSyncs = append(allSyncs, canary.Informer().HasSynced)
+
+		metric := factory.Flagger().V1beta1().MetricTemplates()
+		metricInformers[""] = metric
+		allSyncs = append(allSyncs, metric.Informer().HasSynced)
+
+		alert := factory.Flagger().V1beta1().AlertProviders()
+		alertInformers[""] = alert
+		allSyncs = append(allSyncs, alert.Informer().HasSynced)
+
+	} else {
+		// watch a specific list of namespaces
+		logger.Infof("Watching namespaces: %v", namespaces)
+
+		for _, ns := range namespaces {
+			factory := informers.NewSharedInformerFactoryWithOptions(flaggerClient, time.Second*30, informers.WithNamespace(ns))
+
+			canary := factory.Flagger().V1beta1().Canaries()
+			canaryInformers[ns] = canary // Use string 'ns' as map key
+			allSyncs = append(allSyncs, canary.Informer().HasSynced)
+
+			metric := factory.Flagger().V1beta1().MetricTemplates()
+			metricInformers[ns] = metric
+			allSyncs = append(allSyncs, metric.Informer().HasSynced)
+
+			alert := factory.Flagger().V1beta1().AlertProviders()
+			alertInformers[ns] = alert
+			allSyncs = append(allSyncs, alert.Informer().HasSynced)
+		}
 	}
 
-	logger.Info("Waiting for metric template informer cache to sync")
-	metricInformer := flaggerInformerFactory.Flagger().V1beta1().MetricTemplates()
-	go metricInformer.Informer().Run(stopCh)
-	if ok := cache.WaitForNamedCacheSync("flagger", stopCh, metricInformer.Informer().HasSynced); !ok {
-		logger.Fatalf("failed to wait for cache to sync")
+	logger.Info("Starting informers")
+	for _, inf := range canaryInformers {
+		go inf.Informer().Run(stopCh)
+	}
+	for _, inf := range metricInformers {
+		go inf.Informer().Run(stopCh)
+	}
+	for _, inf := range alertInformers {
+		go inf.Informer().Run(stopCh)
 	}
 
-	logger.Info("Waiting for alert provider informer cache to sync")
-	alertInformer := flaggerInformerFactory.Flagger().V1beta1().AlertProviders()
-	go alertInformer.Informer().Run(stopCh)
-	if ok := cache.WaitForNamedCacheSync("flagger", stopCh, alertInformer.Informer().HasSynced); !ok {
-		logger.Fatalf("failed to wait for cache to sync")
+	logger.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, allSyncs...); !ok {
+		logger.Fatalf("failed to wait for caches to sync")
 	}
 
 	return controller.Informers{
-		CanaryInformer: canaryInformer,
-		MetricInformer: metricInformer,
-		AlertInformer:  alertInformer,
+		CanaryInformers: canaryInformers,
+		MetricInformers: metricInformers,
+		AlertInformers:  alertInformers,
 	}
 }
 
@@ -448,3 +503,4 @@ func verifyKubernetesVersion(kubeClient kubernetes.Interface, logger *zap.Sugare
 
 	logger.Infof("Connected to Kubernetes API %s", ver)
 }
+

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -157,5 +157,40 @@ patches:
               - -mesh-provider=istio
               - -metrics-server=http://prometheus.istio-system:9090
               - -include-label-prefix=app.kubernetes.io
+              - -namespace=production,staging
 EOF
+```
+
+## Namespace Configuration
+
+By default, Flagger watches all namespaces for Canary resources. You can restrict Flagger to watch specific namespaces by setting the `--namespace` flag with a comma-separated list of namespaces:
+
+**Single namespace:**
+```bash
+helm upgrade -i flagger flagger/flagger \
+--namespace=istio-system \
+--set crd.create=false \
+--set meshProvider=istio \
+--set metricsServer=http://prometheus:9090 \
+--set namespace=production
+```
+
+**Multiple namespaces:**
+```bash
+helm upgrade -i flagger flagger/flagger \
+--namespace=istio-system \
+--set crd.create=false \
+--set meshProvider=istio \
+--set metricsServer=http://prometheus:9090 \
+--set namespace=production,staging,testing
+```
+
+**Watch all namespaces (default):**
+```bash
+helm upgrade -i flagger flagger/flagger \
+--namespace=istio-system \
+--set crd.create=false \
+--set meshProvider=istio \
+--set metricsServer=http://prometheus:9090
+# No namespace flag means watch all namespaces
 ```

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,6 +41,7 @@ import (
 	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 	flaggerscheme "github.com/fluxcd/flagger/pkg/client/clientset/versioned/scheme"
 	flaggerinformers "github.com/fluxcd/flagger/pkg/client/informers/externalversions/flagger/v1beta1"
+	flaggerlisters "github.com/fluxcd/flagger/pkg/client/listers/flagger/v1beta1"
 	"github.com/fluxcd/flagger/pkg/metrics"
 	"github.com/fluxcd/flagger/pkg/metrics/observers"
 	"github.com/fluxcd/flagger/pkg/notifier"
@@ -69,6 +70,9 @@ type Controller struct {
 	canaryFactory        *canary.Factory
 	routerFactory        *router.Factory
 	observerFactory      *observers.Factory
+	alertLister          map[string]flaggerlisters.AlertProviderLister
+	canaryLister         map[string]flaggerlisters.CanaryLister
+	metricLister         map[string]flaggerlisters.MetricTemplateLister
 	meshProvider         string
 	eventWebhook         string
 	clusterName          string
@@ -76,9 +80,9 @@ type Controller struct {
 }
 
 type Informers struct {
-	CanaryInformer flaggerinformers.CanaryInformer
-	MetricInformer flaggerinformers.MetricTemplateInformer
-	AlertInformer  flaggerinformers.AlertProviderInformer
+	CanaryInformers map[string]flaggerinformers.CanaryInformer
+	MetricInformers map[string]flaggerinformers.MetricTemplateInformer
+	AlertInformers  map[string]flaggerinformers.AlertProviderInformer
 }
 
 func NewController(
@@ -111,13 +115,33 @@ func NewController(
 	recorder := metrics.NewRecorder(controllerAgentName, true)
 	recorder.SetInfo(version, meshProvider)
 
+	var allInformersSynced []cache.InformerSynced
+	for _, inf := range flaggerInformers.CanaryInformers {
+		allInformersSynced = append(allInformersSynced, inf.Informer().HasSynced)
+	}
+	for _, inf := range flaggerInformers.MetricInformers {
+		allInformersSynced = append(allInformersSynced, inf.Informer().HasSynced)
+	}
+	for _, inf := range flaggerInformers.AlertInformers {
+		allInformersSynced = append(allInformersSynced, inf.Informer().HasSynced)
+	}
+
+	flaggerSyncedFunc := func() bool {
+		for _, synced := range allInformersSynced {
+			if !synced() {
+				return false
+			}
+		}
+		return true
+	}
+
 	ctrl := &Controller{
 		kubeConfig:           kubeConfig,
 		kubeClient:           kubeClient,
 		knativeClient:        knativeClient,
 		flaggerClient:        flaggerClient,
 		flaggerInformers:     flaggerInformers,
-		flaggerSynced:        flaggerInformers.CanaryInformer.Informer().HasSynced,
+		flaggerSynced:        flaggerSyncedFunc,
 		workqueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerAgentName),
 		eventRecorder:        eventRecorder,
 		logger:               logger,
@@ -133,56 +157,71 @@ func NewController(
 		eventWebhook:         eventWebhook,
 		clusterName:          clusterName,
 		noCrossNamespaceRefs: noCrossNamespaceRefs,
+		alertLister:          make(map[string]flaggerlisters.AlertProviderLister),
+		canaryLister:         make(map[string]flaggerlisters.CanaryLister),
+		metricLister:         make(map[string]flaggerlisters.MetricTemplateLister),
 	}
 
-	flaggerInformers.CanaryInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: ctrl.enqueue,
-		UpdateFunc: func(old, new interface{}) {
-			oldCanary, ok := checkCustomResourceType(old, logger)
-			if !ok {
-				return
-			}
-			newCanary, ok := checkCustomResourceType(new, logger)
-			if !ok {
-				return
-			}
+	for ns, inf := range flaggerInformers.CanaryInformers {
+		ctrl.canaryLister[ns] = inf.Lister()
+	}
+	for ns, inf := range flaggerInformers.MetricInformers {
+		ctrl.metricLister[ns] = inf.Lister()
+	}
+	for ns, inf := range flaggerInformers.AlertInformers {
+		ctrl.alertLister[ns] = inf.Lister()
+	}
 
-			if diff := cmp.Diff(newCanary.Spec, oldCanary.Spec); diff != "" {
-				ctrl.logger.Debugf("Diff detected %s.%s %s", oldCanary.Name, oldCanary.Namespace, diff)
-
-				// warn about routing conflicts when service name changes
-				if oldCanary.Spec.Service.Name != "" && oldCanary.Spec.Service.Name != newCanary.Spec.Service.Name {
-					ctrl.logger.With("canary", fmt.Sprintf("%s.%s", oldCanary.Name, oldCanary.Namespace)).
-						Warnf("The service name changed to %s, remove %s objects to avoid routing conflicts",
-							newCanary.Spec.Service.Name, oldCanary.Spec.Service.Name)
-				}
-
-				ctrl.enqueue(new)
-			} else if !newCanary.DeletionTimestamp.IsZero() && hasFinalizer(&newCanary) ||
-				!hasFinalizer(&newCanary) && newCanary.Spec.RevertOnDeletion {
-				// If this was marked for deletion and has finalizers enqueue for finalizing or
-				// if this canary doesn't have finalizers and RevertOnDeletion is true updated speck enqueue
-				ctrl.enqueue(new)
-			}
-
-			// If canary no longer desires reverting, finalizers should be removed
-			if oldCanary.Spec.RevertOnDeletion && !newCanary.Spec.RevertOnDeletion {
-				ctrl.logger.Infof("%s.%s opting out, deleting finalizers", newCanary.Name, newCanary.Namespace)
-				err := ctrl.removeFinalizer(&newCanary)
-				if err != nil {
-					ctrl.logger.Warnf("Failed to remove finalizers for %s.%s: %v", oldCanary.Name, oldCanary.Namespace, err)
+	for _, informer := range flaggerInformers.CanaryInformers {
+		informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: ctrl.enqueue,
+			UpdateFunc: func(old, new any) {
+				oldCanary, ok := checkCustomResourceType(old, logger)
+				if !ok {
 					return
 				}
-			}
-		},
-		DeleteFunc: func(old interface{}) {
-			r, ok := checkCustomResourceType(old, logger)
-			if ok {
-				ctrl.logger.Infof("Deleting %s.%s from cache", r.Name, r.Namespace)
-				ctrl.canaries.Delete(fmt.Sprintf("%s.%s", r.Name, r.Namespace))
-			}
-		},
-	})
+				newCanary, ok := checkCustomResourceType(new, logger)
+				if !ok {
+					return
+				}
+
+				if diff := cmp.Diff(newCanary.Spec, oldCanary.Spec); diff != "" {
+					ctrl.logger.Debugf("Diff detected %s.%s %s", oldCanary.Name, oldCanary.Namespace, diff)
+
+					// warn about routing conflicts when service name changes
+					if oldCanary.Spec.Service.Name != "" && oldCanary.Spec.Service.Name != newCanary.Spec.Service.Name {
+						ctrl.logger.With("canary", fmt.Sprintf("%s.%s", oldCanary.Name, oldCanary.Namespace)).
+							Warnf("The service name changed to %s, remove %s objects to avoid routing conflicts",
+								newCanary.Spec.Service.Name, oldCanary.Spec.Service.Name)
+					}
+
+					ctrl.enqueue(new)
+				} else if !newCanary.DeletionTimestamp.IsZero() && hasFinalizer(&newCanary) ||
+					!hasFinalizer(&newCanary) && newCanary.Spec.RevertOnDeletion {
+					// If this was marked for deletion and has finalizers enqueue for finalizing or
+					// if this canary doesn't have finalizers and RevertOnDeletion is true updated speck enqueue
+					ctrl.enqueue(new)
+				}
+
+				// If canary no longer desires reverting, finalizers should be removed
+				if oldCanary.Spec.RevertOnDeletion && !newCanary.Spec.RevertOnDeletion {
+					ctrl.logger.Infof("%s.%s opting out, deleting finalizers", newCanary.Name, newCanary.Namespace)
+					err := ctrl.removeFinalizer(&newCanary)
+					if err != nil {
+						ctrl.logger.Warnf("Failed to remove finalizers for %s.%s: %v", oldCanary.Name, oldCanary.Namespace, err)
+						return
+					}
+				}
+			},
+			DeleteFunc: func(old any) {
+				r, ok := checkCustomResourceType(old, logger)
+				if ok {
+					ctrl.logger.Infof("Deleting %s.%s from cache", r.Name, r.Namespace)
+					ctrl.canaries.Delete(fmt.Sprintf("%s.%s", r.Name, r.Namespace))
+				}
+			},
+		})
+	}
 
 	return ctrl
 }
@@ -194,7 +233,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 
 	c.logger.Info("Starting operator")
 
-	for i := 0; i < threadiness; i++ {
+	for range threadiness {
 		go wait.Until(func() {
 			for c.processNextWorkItem() {
 			}
@@ -222,7 +261,7 @@ func (c *Controller) processNextWorkItem() bool {
 		return false
 	}
 
-	err := func(obj interface{}) error {
+	err := func(obj any) error {
 		defer c.workqueue.Done(obj)
 		var key string
 		var ok bool
@@ -241,7 +280,6 @@ func (c *Controller) processNextWorkItem() bool {
 		c.workqueue.Forget(obj)
 		return nil
 	}(obj)
-
 	if err != nil {
 		utilruntime.HandleError(err)
 		return true
@@ -256,18 +294,33 @@ func (c *Controller) syncHandler(key string) error {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
-	cd, err := c.flaggerInformers.CanaryInformer.Lister().Canaries(namespace).Get(name)
+
+	// look up the lister for this specific namespace
+	lister, ok := c.canaryLister[namespace]
+	if !ok {
+		// If no specific lister, check for the "all-namespaces" lister
+		lister, ok = c.canaryLister[""]
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("invalid resource key: %s, no lister for namespace %s or all-namespaces", key, namespace))
+			return nil
+		}
+	}
+
+	// get the object from the correct lister
+	cd, err := lister.Canaries(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		utilruntime.HandleError(fmt.Errorf("%s in work queue no longer exists", key))
 		return nil
 	}
+
+	cd = cd.DeepCopy()
 
 	if err := c.verifyCanary(cd); err != nil {
 		return fmt.Errorf("invalid canary spec: %s", err)
 	}
 
 	// Finalize if canary has been marked for deletion and revert is desired
-	if cd.Spec.RevertOnDeletion && cd.ObjectMeta.DeletionTimestamp != nil {
+	if cd.Spec.RevertOnDeletion && cd.DeletionTimestamp != nil {
 		// If finalizers have been previously removed proceed
 		if !hasFinalizer(cd) {
 			c.logger.Infof("Canary %s.%s has been finalized", cd.Name, cd.Namespace)
@@ -311,14 +364,13 @@ func (c *Controller) syncHandler(key string) error {
 		if err := c.addFinalizer(cd); err != nil {
 			return fmt.Errorf("unable to add finalizer to canary %s.%s: %w", cd.Name, cd.Namespace, err)
 		}
-
 	}
 	c.logger.Infof("Synced %s", key)
 
 	return nil
 }
 
-func (c *Controller) enqueue(obj interface{}) {
+func (c *Controller) enqueue(obj any) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
@@ -410,7 +462,7 @@ func verifySessionAffinity(canary *flaggerv1.Canary) error {
 	return nil
 }
 
-func checkCustomResourceType(obj interface{}, logger *zap.SugaredLogger) (flaggerv1.Canary, bool) {
+func checkCustomResourceType(obj any, logger *zap.SugaredLogger) (flaggerv1.Canary, bool) {
 	var roll *flaggerv1.Canary
 	var ok bool
 	if roll, ok = obj.(*flaggerv1.Canary); !ok {
@@ -423,3 +475,4 @@ func checkCustomResourceType(obj interface{}, logger *zap.SugaredLogger) (flagge
 func int32p(i int32) *int32 {
 	return &i
 }
+

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -475,4 +475,3 @@ func checkCustomResourceType(obj any, logger *zap.SugaredLogger) (flaggerv1.Cana
 func int32p(i int32) *int32 {
 	return &i
 }
-

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -29,25 +29,25 @@ import (
 	"github.com/fluxcd/flagger/pkg/notifier"
 )
 
-func (c *Controller) recordEventInfof(r *flaggerv1.Canary, template string, args ...interface{}) {
+func (c *Controller) recordEventInfof(r *flaggerv1.Canary, template string, args ...any) {
 	c.logger.With("canary", fmt.Sprintf("%s.%s", r.Name, r.Namespace)).Infof(template, args...)
 	c.eventRecorder.Event(r, corev1.EventTypeNormal, "Synced", fmt.Sprintf(template, args...))
 	c.sendEventToWebhook(r, corev1.EventTypeNormal, template, args)
 }
 
-func (c *Controller) recordEventErrorf(r *flaggerv1.Canary, template string, args ...interface{}) {
+func (c *Controller) recordEventErrorf(r *flaggerv1.Canary, template string, args ...any) {
 	c.logger.With("canary", fmt.Sprintf("%s.%s", r.Name, r.Namespace)).Errorf(template, args...)
 	c.eventRecorder.Event(r, corev1.EventTypeWarning, "Synced", fmt.Sprintf(template, args...))
 	c.sendEventToWebhook(r, corev1.EventTypeWarning, template, args)
 }
 
-func (c *Controller) recordEventWarningf(r *flaggerv1.Canary, template string, args ...interface{}) {
+func (c *Controller) recordEventWarningf(r *flaggerv1.Canary, template string, args ...any) {
 	c.logger.With("canary", fmt.Sprintf("%s.%s", r.Name, r.Namespace)).Infof(template, args...)
 	c.eventRecorder.Event(r, corev1.EventTypeWarning, "Synced", fmt.Sprintf(template, args...))
 	c.sendEventToWebhook(r, corev1.EventTypeWarning, template, args)
 }
 
-func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template string, args []interface{}) {
+func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template string, args []any) {
 	webhookOverride := false
 	for _, canaryWebhook := range r.GetAnalysis().Webhooks {
 		if canaryWebhook.Type == flaggerv1.EventHook {
@@ -122,8 +122,20 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 			providerNamespace = alert.ProviderRef.Namespace
 		}
 
-		// find alert provider
-		provider, err := c.flaggerInformers.AlertInformer.Lister().AlertProviders(providerNamespace).Get(alert.ProviderRef.Name)
+		// look up the lister for this specific namespace
+		lister, ok := c.alertLister[providerNamespace]
+		if !ok {
+			// if no specific lister, check for the "all-namespaces" lister
+			lister, ok = c.alertLister[""]
+			if !ok {
+				c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
+					Errorf("alert provider %s.%s error: no lister for namespace %s or all-namespaces", alert.ProviderRef.Name, providerNamespace, providerNamespace)
+				continue
+			}
+		}
+
+		// get the object from the correct lister
+		provider, err := lister.AlertProviders(providerNamespace).Get(alert.ProviderRef.Name)
 		if err != nil {
 			c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
 				Errorf("alert provider %s.%s error: %v", alert.ProviderRef.Name, providerNamespace, err)
@@ -241,3 +253,4 @@ func alertMetadata(canary *flaggerv1.Canary) []notifier.Field {
 	}
 	return fields
 }
+

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -253,4 +253,3 @@ func alertMetadata(canary *flaggerv1.Canary) []notifier.Field {
 	}
 	return fields
 }
-

--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -735,4 +735,3 @@ func newDaemonSetTestAlertProvider() *flaggerv1.AlertProvider {
 		},
 	}
 }
-

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -856,4 +856,3 @@ func newDeploymentTestAlertProvider() *flaggerv1.AlertProvider {
 		},
 	}
 }
-

--- a/pkg/controller/scheduler_metrics.go
+++ b/pkg/controller/scheduler_metrics.go
@@ -280,7 +280,12 @@ func (c *Controller) runMetricChecks(canary *flaggerv1.Canary) bool {
 	}
 
 	for _, metric := range canary.GetAnalysis().Metrics {
-		c.recordEventInfof(canary, "metric: %s-%s", metric.Name, metric.TemplateRef)
+		templateRefName := ""
+		if metric.TemplateRef != nil {
+			templateRefName = metric.TemplateRef.Name
+		}
+		c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
+			Debugf("Processing metric: %s-%s", metric.Name, templateRefName)
 		if metric.TemplateRef != nil {
 			namespace := canary.Namespace
 			if metric.TemplateRef.Namespace != canary.Namespace && metric.TemplateRef.Namespace != "" {
@@ -348,7 +353,8 @@ func (c *Controller) runMetricChecks(canary *flaggerv1.Canary) bool {
 				return false
 			}
 
-			c.recordEventInfof(canary, "Metric %s reported value: %v for %s.%s", metric.Name, val, canary.Name, canary.Namespace)
+			c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
+				Debugf("Metric %s reported value: %v", metric.Name, val)
 			c.recorder.SetAnalysis(canary, metric.Name, val)
 
 			if metric.ThresholdRange != nil {
@@ -401,4 +407,3 @@ func toMetricModel(r *flaggerv1.Canary, interval string, variables map[string]st
 		Variables: variables,
 	}
 }
-

--- a/pkg/metrics/providers/factory.go
+++ b/pkg/metrics/providers/factory.go
@@ -33,6 +33,8 @@ func (factory Factory) Provider(metricInterval string, provider flaggerv1.Metric
 		return NewCloudWatchProvider(metricInterval, provider)
 	case "newrelic":
 		return NewNewRelicProvider(metricInterval, provider, credentials)
+	case "newrelic-nerdgraph":
+		return NewNerdGraphProvider(metricInterval, provider, credentials)
 	case "graphite":
 		return NewGraphiteProvider(provider, credentials)
 	case "stackdriver":

--- a/pkg/metrics/providers/newrelic-nerdgraph.go
+++ b/pkg/metrics/providers/newrelic-nerdgraph.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+)
+
+const (
+	nerdGraphDefaultHost       = "https://api.newrelic.com/graphql"
+	nerdGraphAPIKeySecretKey   = "newrelic_api_key"
+	nerdGraphAPIKeyHeaderKey   = "Api-Key"
+	nerdGraphContentTypeHeader = "application/json"
+
+	nerdGraphRunQueryTemplate = `
+	query {
+	  actor {
+	    account(id: %s) {
+	      nrql(query: """
+	        %s SINCE %s SECONDS ago
+	      """) {
+	        results
+	      }
+	    }
+	  }
+	}`
+)
+
+// NerdGraphProvider executes New Relic NerdGraph queries
+type NerdGraphProvider struct {
+	endpoint  string
+	timeout   time.Duration
+	apiKey    string
+	accountID string
+	fromDelta int64
+}
+
+// nerdGraphQuery is the JSON payload for a GraphQL request
+type nerdGraphQuery struct {
+	Query string `json:"query"`
+}
+
+// nerdGraphGQLResponse is the generic wrapper for a GraphQL response
+type nerdGraphGQLResponse struct {
+	Data   map[string]any   `json:"data"`
+	Errors []nerdGraphError `json:"errors"`
+}
+
+// nerdGraphError represents a single error in a GraphQL response
+type nerdGraphError struct {
+	Message string `json:"message"`
+}
+
+// NewNerdGraphProvider takes a canary spec, a provider spec and the credentials map, and
+// returns a NewRelic client ready to execute queries against the NerdGraph API
+func NewNerdGraphProvider(
+	metricInterval string,
+	provider flaggerv1.MetricTemplateProvider,
+	credentials map[string][]byte,
+) (*NerdGraphProvider, error) {
+	address := provider.Address
+	if address == "" {
+		address = nerdGraphDefaultHost
+	}
+
+	apiKey, ok := credentials[nerdGraphAPIKeySecretKey]
+	if !ok {
+		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", nerdGraphAPIKeySecretKey)
+	}
+
+	accountIDBytes, ok := credentials[newrelicAccountIdSecretKey]
+	if !ok {
+		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", newrelicAccountIdSecretKey)
+	}
+	accountID := string(accountIDBytes)
+	if _, err := strconv.Atoi(accountID); err != nil {
+		return nil, fmt.Errorf("newrelic account ID '%s' is not a valid integer: %w", accountID, err)
+	}
+
+	md, err := time.ParseDuration(metricInterval)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing metric interval: %w", err)
+	}
+
+	return &NerdGraphProvider{
+		timeout:   5 * time.Second,
+		endpoint:  address,
+		apiKey:    string(apiKey),
+		accountID: accountID,
+		fromDelta: int64(md.Seconds()),
+	}, nil
+}
+
+// RunQuery executes the NerdGraph query and returns the first numeric result
+func (p *NerdGraphProvider) RunQuery(query string) (float64, error) {
+	since := strconv.FormatInt(p.fromDelta, 10)
+	fullQuery := fmt.Sprintf(nerdGraphRunQueryTemplate, p.accountID, query, since)
+
+	req, err := p.newNerdGraphRequest(fullQuery)
+	if err != nil {
+		return 0, err
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), p.timeout)
+	defer cancel()
+	r, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return 0, fmt.Errorf("request failed: %w", err)
+	}
+
+	defer r.Body.Close()
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return 0, fmt.Errorf("error reading body: %w", err)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("error response: %s", string(b))
+	}
+
+	var res nerdGraphGQLResponse
+	if err := json.Unmarshal(b, &res); err != nil {
+		return 0, fmt.Errorf("error unmarshaling result: %w, '%s'", err, string(b))
+	}
+
+	if len(res.Errors) > 0 {
+		return 0, fmt.Errorf("nerdgraph query failed: %s", res.Errors[0].Message)
+	}
+
+	if res.Data == nil {
+		return 0, fmt.Errorf("invalid response, no data found: %s", string(b))
+	}
+
+	// Recursively find the first numeric value in the first 'results' array
+	val, err := findResultValue(res.Data)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing nerdgraph response: %w, body: '%s'", err, string(b))
+	}
+
+	return val, nil
+}
+
+// IsOnline checks if the NerdGraph API is reachable and credentials are valid
+func (p *NerdGraphProvider) IsOnline() (bool, error) {
+	pingQuery := "{ actor { user { name } } }"
+	req, err := p.newNerdGraphRequest(pingQuery)
+	if err != nil {
+		return false, fmt.Errorf("error creating http.NewRequest: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), p.timeout)
+	defer cancel()
+	r, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return false, fmt.Errorf("request failed: %w", err)
+	}
+	defer r.Body.Close()
+
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false, fmt.Errorf("error reading body: %w", err)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("error response: %s", string(b))
+	}
+
+	var res nerdGraphGQLResponse
+	if err := json.Unmarshal(b, &res); err != nil {
+		return false, fmt.Errorf("error unmarshaling response: %w, '%s'", err, string(b))
+	}
+
+	if len(res.Errors) > 0 {
+		return false, fmt.Errorf("nerdgraph query failed: %s", res.Errors[0].Message)
+	}
+
+	return true, nil
+}
+
+// newNerdGraphRequest creates a new HTTP POST request for the NerdGraph API
+func (p *NerdGraphProvider) newNerdGraphRequest(query string) (*http.Request, error) {
+	gqlQuery := nerdGraphQuery{Query: query}
+	payload, err := json.Marshal(gqlQuery)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling query: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.endpoint, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("error creating http.NewRequest: %w", err)
+	}
+
+	req.Header.Set(nerdGraphAPIKeyHeaderKey, p.apiKey)
+	req.Header.Set("Content-Type", nerdGraphContentTypeHeader)
+
+	return req, nil
+}
+
+// findResultValue recursively searches a map for the first 'results' array,
+// then returns the first float64 value from the first object in that array.
+func findResultValue(data map[string]any) (float64, error) {
+	for key, val := range data {
+		// 1. Found a 'results' array?
+		if key == "results" {
+			if results, ok := val.([]any); ok && len(results) > 0 {
+				// 2. Get the first object in the array
+				if firstResult, ok := results[0].(map[string]any); ok {
+					// 3. Find the first float64 value in that object
+					for _, resultVal := range firstResult {
+						if f, ok := resultVal.(float64); ok {
+							return f, nil
+						}
+					}
+				}
+			}
+		}
+
+		// 4. Not 'results'? Recurse if it's another map
+		if subMap, ok := val.(map[string]any); ok {
+			if res, err := findResultValue(subMap); err == nil {
+				return res, nil // Found it nested deeper
+			}
+		}
+	}
+
+	// 5. Searched everywhere, no result
+	return 0, ErrNoValuesFound
+}

--- a/pkg/metrics/providers/newrelic-nerdgraph.go
+++ b/pkg/metrics/providers/newrelic-nerdgraph.go
@@ -30,10 +30,11 @@ import (
 )
 
 const (
-	nerdGraphDefaultHost       = "https://api.newrelic.com/graphql"
-	nerdGraphAPIKeySecretKey   = "newrelic_api_key"
-	nerdGraphAPIKeyHeaderKey   = "Api-Key"
-	nerdGraphContentTypeHeader = "application/json"
+	nerdGraphDefaultHost        = "https://api.newrelic.com/graphql"
+	nerdGraphAPIKeySecretKey    = "newrelic_api_key"
+	nerdGraphAccountIDSecretKey = "newrelic_account_id"
+	nerdGraphAPIKeyHeaderKey    = "Api-Key"
+	nerdGraphContentTypeHeader  = "application/json"
 
 	nerdGraphRunQueryTemplate = `
 	query ($query: Nrql!) {
@@ -94,9 +95,9 @@ func NewNerdGraphProvider(
 		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", nerdGraphAPIKeySecretKey)
 	}
 
-	accountIDBytes, ok := credentials[newrelicAccountIdSecretKey]
+	accountIDBytes, ok := credentials[nerdGraphAccountIDSecretKey]
 	if !ok {
-		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", newrelicAccountIdSecretKey)
+		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", nerdGraphAccountIDSecretKey)
 	}
 	accountID := string(accountIDBytes)
 	if _, err := strconv.Atoi(accountID); err != nil {

--- a/pkg/metrics/providers/newrelic-nerdgraph.go
+++ b/pkg/metrics/providers/newrelic-nerdgraph.go
@@ -30,10 +30,11 @@ import (
 )
 
 const (
-	nerdGraphDefaultHost       = "https://api.newrelic.com/graphql"
-	nerdGraphAPIKeySecretKey   = "newrelic_api_key"
-	nerdGraphAPIKeyHeaderKey   = "Api-Key"
-	nerdGraphContentTypeHeader = "application/json"
+	nerdGraphDefaultHost        = "https://api.newrelic.com/graphql"
+	nerdGraphAPIKeySecretKey    = "newrelic_api_key"
+	nerdGraphAccountIDSecretKey = "newrelic_account_id"
+	nerdGraphAPIKeyHeaderKey    = "Api-Key"
+	nerdGraphContentTypeHeader  = "application/json"
 
 	nerdGraphRunQueryTemplate = `
 	query {
@@ -91,9 +92,9 @@ func NewNerdGraphProvider(
 		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", nerdGraphAPIKeySecretKey)
 	}
 
-	accountIDBytes, ok := credentials[newrelicAccountIdSecretKey]
+	accountIDBytes, ok := credentials[nerdGraphAccountIDSecretKey]
 	if !ok {
-		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", newrelicAccountIdSecretKey)
+		return nil, fmt.Errorf("newrelic credentials does not contain the key '%s'", nerdGraphAccountIDSecretKey)
 	}
 	accountID := string(accountIDBytes)
 	if _, err := strconv.Atoi(accountID); err != nil {

--- a/pkg/metrics/providers/newrelic-nerdgraph_test.go
+++ b/pkg/metrics/providers/newrelic-nerdgraph_test.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under theLicense.
+limitations under the License.
 */
 
 package providers

--- a/pkg/metrics/providers/newrelic-nerdgraph_test.go
+++ b/pkg/metrics/providers/newrelic-nerdgraph_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+)
+
+func TestNewNerdGraphProvider(t *testing.T) {
+	apiKey := "api-key"
+	accountID := "1234567"
+
+	t.Run("default host", func(t *testing.T) {
+		cs := map[string][]byte{
+			"newrelic_api_key":    []byte(apiKey),
+			"newrelic_account_id": []byte(accountID),
+		}
+
+		provider, err := NewNerdGraphProvider("1m", flaggerv1.MetricTemplateProvider{}, cs)
+		require.NoError(t, err)
+		assert.Equal(t, nerdGraphDefaultHost, provider.endpoint)
+		assert.Equal(t, apiKey, provider.apiKey)
+		assert.Equal(t, accountID, provider.accountID)
+	})
+
+	t.Run("custom host", func(t *testing.T) {
+		cs := map[string][]byte{
+			"newrelic_api_key":    []byte(apiKey),
+			"newrelic_account_id": []byte(accountID),
+		}
+		customHost := "https://my-custom.newrelic.com/graphql"
+
+		provider, err := NewNerdGraphProvider("1m", flaggerv1.MetricTemplateProvider{Address: customHost}, cs)
+		require.NoError(t, err)
+		assert.Equal(t, customHost, provider.endpoint)
+	})
+
+	t.Run("missing api key", func(t *testing.T) {
+		cs := map[string][]byte{
+			"newrelic_account_id": []byte(accountID),
+		}
+		_, err := NewNerdGraphProvider("1m", flaggerv1.MetricTemplateProvider{}, cs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), nerdGraphAPIKeySecretKey)
+	})
+
+	t.Run("missing account id", func(t *testing.T) {
+		cs := map[string][]byte{
+			"newrelic_api_key": []byte(apiKey),
+		}
+		_, err := NewNerdGraphProvider("1m", flaggerv1.MetricTemplateProvider{}, cs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), newrelicAccountIdSecretKey)
+	})
+
+	t.Run("invalid account id", func(t *testing.T) {
+		cs := map[string][]byte{
+			"newrelic_api_key":    []byte(apiKey),
+			"newrelic_account_id": []byte("not-an-integer"),
+		}
+		_, err := NewNerdGraphProvider("1m", flaggerv1.MetricTemplateProvider{}, cs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid integer")
+	})
+}
+
+func TestNerdGraphProvider_RunQuery(t *testing.T) {
+	apiKey := "api-key"
+	accountID := "12345"
+
+	t.Run("ok", func(t *testing.T) {
+		nrqlQuery := "SELECT average(duration) FROM Transaction"
+
+		expectedResult := 1.11111
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, apiKey, r.Header.Get(nerdGraphAPIKeyHeaderKey))
+			assert.Equal(t, nerdGraphContentTypeHeader, r.Header.Get("Content-Type"))
+
+			var reqBody nerdGraphQuery
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(b, &reqBody)
+			require.NoError(t, err)
+
+			assert.Contains(t, reqBody.Query, fmt.Sprintf("account(id: %s)", accountID))
+			assert.Contains(t, reqBody.Query, nrqlQuery)
+			assert.Contains(t, reqBody.Query, "SINCE 60 SECONDS ago")
+
+			jsonResp := fmt.Sprintf(`{"data": {"actor": {"account": {"nrql": {"results": [{"average": %f}]}}}}}`, expectedResult)
+			w.Write([]byte(jsonResp))
+		}))
+		defer ts.Close()
+
+		provider, err := NewNerdGraphProvider("1m",
+			flaggerv1.MetricTemplateProvider{
+				Address: ts.URL,
+			},
+			map[string][]byte{
+				"newrelic_api_key":    []byte(apiKey),
+				"newrelic_account_id": []byte(accountID),
+			},
+		)
+		require.NoError(t, err)
+
+		val, err := provider.RunQuery(nrqlQuery)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, val)
+	})
+
+	t.Run("no values found", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"data": {"actor": {"account": {"nrql": {"results": []}}}}}`))
+		}))
+		defer ts.Close()
+
+		provider, err := NewNerdGraphProvider(
+			"1m",
+			flaggerv1.MetricTemplateProvider{Address: ts.URL},
+			map[string][]byte{
+				"newrelic_api_key":    []byte(apiKey),
+				"newrelic_account_id": []byte(accountID),
+			},
+		)
+		require.NoError(t, err)
+		_, err = provider.RunQuery("SELECT * FROM X")
+		require.True(t, errors.Is(err, ErrNoValuesFound))
+	})
+
+	t.Run("no numeric value in result", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"data": {"actor": {"account": {"nrql": {"results": [{"string": "not-a-float"}]}}}}}`))
+		}))
+		defer ts.Close()
+
+		provider, err := NewNerdGraphProvider(
+			"1m",
+			flaggerv1.MetricTemplateProvider{Address: ts.URL},
+			map[string][]byte{
+				"newrelic_api_key":    []byte(apiKey),
+				"newrelic_account_id": []byte(accountID),
+			},
+		)
+		require.NoError(t, err)
+		_, err = provider.RunQuery("SELECT * FROM X")
+		require.True(t, errors.Is(err, ErrNoValuesFound))
+	})
+
+	t.Run("graphql error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"errors": [{"message": "Invalid query"}]}`))
+		}))
+		defer ts.Close()
+
+		provider, err := NewNerdGraphProvider(
+			"1m",
+			flaggerv1.MetricTemplateProvider{Address: ts.URL},
+			map[string][]byte{
+				"newrelic_api_key":    []byte(apiKey),
+				"newrelic_account_id": []byte(accountID),
+			},
+		)
+		require.NoError(t, err)
+		_, err = provider.RunQuery("SELECT * FROM X")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid query")
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer ts.Close()
+
+		provider, err := NewNerdGraphProvider(
+			"1m",
+			flaggerv1.MetricTemplateProvider{Address: ts.URL},
+			map[string][]byte{
+				"newrelic_api_key":    []byte(apiKey),
+				"newrelic_account_id": []byte(accountID),
+			},
+		)
+		require.NoError(t, err)
+		_, err = provider.RunQuery("SELECT * FROM X")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error response")
+	})
+}
+
+func TestNerdGraphProvider_IsOnline(t *testing.T) {
+	apiKey := "api-key"
+	accountID := "12345"
+	pingQuery := "{ actor { user { name } } }"
+
+	type testCase struct {
+		name        string
+		code        int
+		body        string
+		errExpected bool
+	}
+
+	for _, c := range []testCase{
+		{name: "ok", code: http.StatusOK, body: `{"data": {"actor": {"user": {"name": "test"}}}}`, errExpected: false},
+		{name: "http error", code: http.StatusUnauthorized, body: ``, errExpected: true},
+		{name: "graphql error", code: http.StatusOK, body: `{"errors": [{"message": "Invalid API Key"}]}`, errExpected: true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, apiKey, r.Header.Get(nerdGraphAPIKeyHeaderKey))
+
+				var reqBody nerdGraphQuery
+				b, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				if len(b) > 0 {
+					err = json.Unmarshal(b, &reqBody)
+					require.NoError(t, err)
+					assert.Equal(t, pingQuery, reqBody.Query)
+				}
+
+				w.WriteHeader(c.code)
+				if c.body != "" {
+					w.Write([]byte(c.body))
+				}
+			}))
+			defer ts.Close()
+
+			provider, err := NewNerdGraphProvider(
+				"1m",
+				flaggerv1.MetricTemplateProvider{Address: ts.URL},
+				map[string][]byte{
+					"newrelic_api_key":    []byte(apiKey),
+					"newrelic_account_id": []byte(accountID),
+				},
+			)
+			require.NoError(t, err)
+
+			_, err = provider.IsOnline()
+			if c.errExpected {
+				require.Error(t, err)
+				if c.name == "graphql error" {
+					assert.Contains(t, err.Error(), "Invalid API Key")
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Helper to test the recursive findResultValue function directly
+func Test_findResultValue(t *testing.T) {
+	t.Run("finds nested result", func(t *testing.T) {
+		data := map[string]any{
+			"actor": map[string]any{
+				"account": map[string]any{
+					"nrql": map[string]any{
+						"results": []any{
+							map[string]any{
+								"average": 123.45,
+								"other":   "foo",
+							},
+						},
+					},
+				},
+			},
+		}
+		val, err := findResultValue(data)
+		require.NoError(t, err)
+		assert.Equal(t, 123.45, val)
+	})
+
+	t.Run("finds first numeric value", func(t *testing.T) {
+		data := map[string]any{
+			"results": []any{
+				map[string]any{
+					"string":  "foo",
+					"count":   99.0, // This should be found
+					"average": 123.45,
+				},
+			},
+		}
+		val, err := findResultValue(data)
+		require.NoError(t, err)
+		assert.Equal(t, 99.0, val)
+	})
+
+	t.Run("returns error for empty results", func(t *testing.T) {
+		data := map[string]any{
+			"actor": map[string]any{
+				"nrql": map[string]any{
+					"results": []any{},
+				},
+			},
+		}
+		_, err := findResultValue(data)
+		require.True(t, errors.Is(err, ErrNoValuesFound))
+	})
+
+	t.Run("returns error for no numeric value", func(t *testing.T) {
+		data := map[string]any{
+			"results": []any{
+				map[string]any{
+					"string": "foo",
+					"bool":   true,
+				},
+			},
+		}
+		_, err := findResultValue(data)
+		require.True(t, errors.Is(err, ErrNoValuesFound))
+	})
+}
+


### PR DESCRIPTION
# Contribution Details

## PR Description

This PR adds two significant enhancements to Flagger:

**Namespace Scoping Support** - Allows Flagger to watch specific namespaces instead of all namespaces #1859 
**New Relic NerdGraph Provider** - Adds support for New Relic's GraphQL API for custom metrics #1860 

## What This PR Does

### Namespace Scoping Feature
Problem: Previously, Flagger could only watch all namespaces in a cluster, which wasn't ideal for multi-tenant environments or when you only want to manage canaries in specific namespaces.

#### Multi-Tenancy Issues:

**Security Isolation**: Watching all namespaces meant Flagger had cluster-wide permissions and could potentially access sensitive deployment information across tenant boundaries.

**Resource Conflicts**: Multiple teams using Flagger in the same cluster could experience naming conflicts or unintended interactions between their canary configurations.

**Compliance Requirements**: Organizations may have strict compliance requirements that mandate workload isolation between different business units, environments, or customers.

#### Operational Challenges:

**Noise and Complexity**: Operators had to sift through logs and metrics from all namespaces, making troubleshooting and monitoring more difficult when they only cared about a specific namespace.

**RBAC Complexity**: Organizations couldn't implement least-privilege access patterns where Flagger instances should only have permissions for specific namespaces they're responsible for managing.
Environment Separation:

**Development vs Production**: Teams often want separate Flagger instances for different environments, but the all-namespace approach made it impossible to cleanly separate development canaries from production ones.

**Staged Rollouts**: Organizations implementing progressive delivery across multiple environments need better control over which Flagger instance manages which namespace.

**This limitation forced many organizations to either**:

* Deploy multiple Flagger instances in separate clusters (expensive and complex)
* Accept the security and performance trade-offs of cluster-wide access
* The namespace scoping feature solves these problems by allowing administrators to precisely control which namespaces each Flagger instance monitors, enabling true multi-tenant deployments with proper security isolation and improved operational efficiency.

**Solution**: Modified --namespace flag that accepts a comma-separated list of namespaces to watch.

Key Changes:

Modified:
* `cmd/flagger/main.go` to parse namespace flag and create namespace-specific informers
* Updated controller logic in `pkg/controller/` to handle both namespace-specific and all-namespace listers
* Added fallback logic: if a resource isn't found in a specific namespace lister, it checks the "all-namespaces" lister
* Updated installation documentation with examples for single namespace, multiple namespaces, and all namespaces (default)

```bash
# Watch specific namespace
--set namespace=production

# Watch multiple namespaces  
--set namespace=production,staging,testing

# Watch all namespaces (default behavior)
# No namespace flag needed
```

### New Relic NerdGraph Provider
**Problem**: The existing New Relic provider only used the Insights API. New Relic currently recommends using the NerdGraph (GraphQL) API. This is also the API we use at Capital One.

**Solution**: Implemented a NerdGraph provider that wraps NRQL queries in GraphQL and supports template variables.

Key Features:

* GraphQL API Integration: Uses New Relic's NerdGraph API for more flexible querying
* Template Variable Support: Supports all Flagger template variables (`{{ target }}`, `{{ namespace }}`, etc.)
* Automatic Query Wrapping: Automatically wraps NRQL queries with proper GraphQL structure and time windows
* Robust Error Handling: Comprehensive error handling for API responses and data parsing
* Credential Management: Secure handling of API keys and account IDs via Kubernetes secrets

Implementation Details:

Added :
* `pkg/metrics/providers/newrelic-nerdgraph.go` with full provider implementation
* Comprehensive tests in `pkg/metrics/providers/newrelic-nerdgraph_test.go`
* Updated factory to register the new provider
* Added detailed documentation with examples

```yaml
apiVersion: flagger.app/v1beta1
kind: MetricTemplate
metadata:
  name: nerdgraph-success-rate
spec:
  provider:
    type: newrelic-nerdgraph
    secretRef:
      name: newrelic-secret
  query: |
    SELECT percentage(count(*), WHERE response.status != 'error') 
    FROM Transaction 
    WHERE appName = '{{ target }}'
```

