### PR TITLE
docs: fix typo in stepWeights usage

### DIFF
--- a/docs/gitbook/usage/deployment-strategies.md
+++ b/docs/gitbook/usage/deployment-strategies.md
@@ -160,7 +160,7 @@ We would have steps (canary weight : primary weight):
 * 1 (1 : 99)
 * 2 (2 : 98)
 * 10 (10 : 90)
-* 80 (20 : 60)
+* 80 (80 : 20)
 * promotion
 
 ## A/B Testing


### PR DESCRIPTION
Resolves a typo in the usage documentation when explaining the stepWeights property. 