### PR TITLE
Update e2e environment to Kubernetes 1.35

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,12 +40,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Setup Kubernetes
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
         if: matrix.provider != 'skipper'
         with:
-          version: v0.23.0
+          version: v0.27.0
           cluster_name: kind
-          node_image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+          node_image: kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
       - name: Setup Kubernetes for skipper
         uses: helm/kind-action@v1.12.0
         if: matrix.provider == 'skipper'

--- a/pkg/router/gateway_api.go
+++ b/pkg/router/gateway_api.go
@@ -369,10 +369,6 @@ func (gwr *GatewayAPIRouter) SetRoutes(
 			},
 		})
 	}
-	var timeout v1.Duration
-	if canary.Spec.Service.Timeout != "" {
-		timeout = v1.Duration(canary.Spec.Service.Timeout)
-	}
 
 	weightedRouteRule := &v1.HTTPRouteRule{
 		Matches: matches,
@@ -440,9 +436,6 @@ func (gwr *GatewayAPIRouter) SetRoutes(
 				{
 					BackendRef: gwr.makeBackendRef(primarySvcName, initialPrimaryWeight, canary.Spec.Service.Port),
 				},
-			},
-			Timeouts: &v1.HTTPRouteTimeouts{
-				Request: &timeout,
 			},
 		})
 

--- a/test/gatewayapi/install.sh
+++ b/test/gatewayapi/install.sh
@@ -2,9 +2,9 @@
 
 set -o errexit
 
-GATEWAY_API_VER="v1.0.0"
+GATEWAY_API_VER="v1.5.1"
 REPO_ROOT=$(git rev-parse --show-toplevel)
-ISTIO_VER="1.20.0"
+ISTIO_VER="1.29.2"
 
 mkdir -p ${REPO_ROOT}/bin
 

--- a/test/istio/install.sh
+++ b/test/istio/install.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.18.2"
+ISTIO_VER="1.29.2"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 mkdir -p ${REPO_ROOT}/bin


### PR DESCRIPTION
this PR makes the following bumps in ci:
* kind to 0.27.0
* kubernetes to 1.35.1
* istio to 1.29.2
* gateway api to 1.5.1