### PR TITLE
feat: add support istio's splitExternalLocalOriginErrors and consecutiveLocalOriginFailures

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -859,6 +859,12 @@ spec:
                                 ejected from the connection pool.
                               format: int32
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: Number of consecutive locally originated
+                                failures before ejection. Takes effect only when
+                                splitExternalLocalOriginErrors is set to true.
+                              format: int32
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -868,6 +874,10 @@ spec:
                             minHealthPercent:
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                         tls:
                           description: Istio TLS related settings for connections to the upstream service
                           type: object

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -859,6 +859,12 @@ spec:
                                 ejected from the connection pool.
                               format: int32
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: Number of consecutive locally originated
+                                failures before ejection. Takes effect only when
+                                splitExternalLocalOriginErrors is set to true.
+                              format: int32
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -868,6 +874,10 @@ spec:
                             minHealthPercent:
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                         tls:
                           description: Istio TLS related settings for connections to the upstream service
                           type: object

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -859,6 +859,12 @@ spec:
                                 ejected from the connection pool.
                               format: int32
                               type: integer
+                            consecutiveLocalOriginFailures:
+                              description: Number of consecutive locally originated
+                                failures before ejection. Takes effect only when
+                                splitExternalLocalOriginErrors is set to true.
+                              format: int32
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -868,6 +874,10 @@ spec:
                             minHealthPercent:
                               format: int32
                               type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
                         tls:
                           description: Istio TLS related settings for connections to the upstream service
                           type: object

--- a/pkg/apis/istio/v1beta1/destination_rule.go
+++ b/pkg/apis/istio/v1beta1/destination_rule.go
@@ -620,6 +620,21 @@ type OutlierDetection struct {
 	// no effect.
 	Consecutive5xxErrors *uint32 `json:"consecutive5xxErrors,omitempty"`
 
+	// Determines whether to distinguish local origin failures from external errors. If set to true
+	// `consecutiveLocalOriginFailures` is taken into account for outlier detection calculations.
+	// This should be used when you want to derive the outlier detection status based on the errors
+	// seen locally such as failure to connect, timeout while connecting etc. rather than the status code
+	// returned by upstream service. This is especially useful when the upstream service explicitly returns
+	// a 5xx for some requests and you want to ignore those responses from upstream service while determining
+	// the outlier detection status of a host.
+	// Defaults to false.
+	SplitExternalLocalOriginErrors bool `json:"splitExternalLocalOriginErrors,omitempty"`
+
+	// The number of consecutive locally originated failures before ejection
+	// occurs. Defaults to 5. Parameter takes effect only when `splitExternalLocalOriginErrors`
+	// is set to true.
+	ConsecutiveLocalOriginFailures *uint32 `json:"consecutiveLocalOriginFailures,omitempty"`
+
 	// Time interval between ejection sweep analysis. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	Interval string `json:"interval,omitempty"`

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -728,6 +728,11 @@ func (in *OutlierDetection) DeepCopyInto(out *OutlierDetection) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.ConsecutiveLocalOriginFailures != nil {
+		in, out := &in.ConsecutiveLocalOriginFailures, &out.ConsecutiveLocalOriginFailures
+		*out = new(uint32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Closes #1905

## Summary
Adds the two remaining Istio `OutlierDetection` fields to `trafficPolicy.outlierDetection`:

- `splitExternalLocalOriginErrors` (bool)
- `consecutiveLocalOriginFailures` (*uint32)

With these, Envoy can eject upstreams on locally-originated failures (connect timeout, TCP reset) separately from upstream 5xx responses.

## Changes

- Added the two fields to the `OutlierDetection` struct (regenerated deepcopy)
- Added them to the Canary CRD schema

## Testing
Verified locally against kind (Kubernetes 1.35.1) with Istio 1.29.2, using a Flagger image built from this branch.
A Canary with: 
```yaml
trafficPolicy:
  outlierDetection:
    splitExternalLocalOriginErrors: true
    consecutiveLocalOriginFailures: 3
    interval: 30s
    baseEjectionTime: 1m
```
is accepted by the API server and produces `podinfo-primary` / `podinfo-canary` DestinationRules containing both new fields.

End-to-end propagation down to the Envoy sidecar confirmed via `istioctl proxy-config cluster`: 

```json
{
  "name": "outbound|9898||podinfo-primary.test.svc.cluster.local",
  "outlierDetection": {
    "interval": "30s",
    "baseEjectionTime": "60s",
    "splitExternalLocalOriginErrors": true,
    "consecutiveLocalOriginFailure": 3,
    "enforcingConsecutiveLocalOriginFailure": 100
  }
}
```
