### PR TITLE
chore: typo `existant` -> `existent` in skipper router comment

### DIFF
--- a/pkg/router/skipper.go
+++ b/pkg/router/skipper.go
@@ -128,7 +128,7 @@ func (skp *SkipperRouter) Reconcile(canary *flaggerv1.Canary) error {
 		return fmt.Errorf("ingress %s.%s query error: %w", canaryIngressName, canary.Namespace, err)
 	}
 
-	// existant, updating
+	// existent, updating
 	if cmp.Diff(iClone.Spec, canaryIngress.Spec) != "" {
 		ingressClone := canaryIngress.DeepCopy()
 		ingressClone.Spec = iClone.Spec


### PR DESCRIPTION
One-character typo fix inside `pkg/router/skipper.go:131`. No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>