### PR TITLE
feat: add podSecurityContext option

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -190,6 +190,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext.context | indent 12 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -192,7 +192,7 @@ spec:
     {{- end }}
     {{- if .Values.podSecurityContext.enabled }}
       securityContext:
-{{ toYaml .Values.podSecurityContext.context | indent 12 }}
+{{ toYaml .Values.podSecurityContext.context | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -52,8 +52,8 @@ ingressAnnotationsPrefix: ""
 # ingress class used for annotating HTTPProxy objects
 ingressClass: ""
 
-# when enabled, it will add a container level security context for the flagger pod. You may
-# need to disable this if you are running flagger on OpenShift
+# when enabled, it will add a container level security context for the flagger pod. 
+# You may need to disable this if you are running flagger on OpenShift
 securityContext:
   enabled: true
   context:
@@ -63,8 +63,8 @@ securityContext:
     privileged: false
     readOnlyRootFilesystem: true
     
-# when enabled, it will add a pod level security context for the flagger pod. You may
-# need to disable this if you are running flagger on OpenShift
+# when enabled, it will add a pod level security context for the flagger pod. 
+# You may need to disable this if you are running flagger on OpenShift
 podSecurityContext:
   enabled: true
   context:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -52,13 +52,27 @@ ingressAnnotationsPrefix: ""
 # ingress class used for annotating HTTPProxy objects
 ingressClass: ""
 
-# when enabled, it will add a security context for the flagger pod. You may
+# when enabled, it will add a container level security context for the flagger pod. You may
 # need to disable this if you are running flagger on OpenShift
 securityContext:
   enabled: true
   context:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+    privileged: false
     readOnlyRootFilesystem: true
+    
+# when enabled, it will add a pod level security context for the flagger pod. You may
+# need to disable this if you are running flagger on OpenShift
+podSecurityContext:
+  enabled: true
+  context:
+    runAsGroup: 10001
+    runAsNonRoot: true
     runAsUser: 10001
+    fsGroup: 10001
+    supplementalGroups: [10001]
 
 # when specified, flagger will publish events to the provided webhook
 eventWebhook: ""


### PR DESCRIPTION
## Description
Adds option to specify securityContext on pod level to be able to address Pod Security Standards natively in the helm chart.

## Motivation
We want flagger to be able to run in restricted environments natively as well. Currently we are doing some workarounds with `postRenderers` in its `HelmRelease`, but being able to configure these settings directly in the values would be a nice quality-of-life improvement in order to reduce general complexity.

## Changes
* added section for securityContext on pod level in flagger deployment template as opt-in value (default: enabled)
* refactored comments and default securityContext on container and pod level

## Verification
Just ran 
```bash
helm template flagger charts/flagger
```
to verify the desired outcome as shown below:
```YAML
# Source: flagger/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: flagger
  namespace: default
  labels:
    helm.sh/chart: flagger-1.43.0
    app.kubernetes.io/name: flagger
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: flagger
    app.kubernetes.io/version: 1.43.0
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/name: flagger
      app.kubernetes.io/instance: flagger
  template:
    metadata:
      labels:
        app.kubernetes.io/name: flagger
        app.kubernetes.io/instance: flagger
        app.kubernetes.io/version: 1.43.0
      annotations:
        appmesh.k8s.aws/sidecarInjectorWebhook: disabled
        linkerd.io/inject: enabled
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
    spec:
      serviceAccountName: flagger
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app.kubernetes.io/instance: 'flagger'
                  app.kubernetes.io/name: 'flagger'
              topologyKey: kubernetes.io/hostname
            weight: 100                  
      containers:
        - name: flagger
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
          image: "ghcr.io/fluxcd/flagger:1.43.0"
          imagePullPolicy: IfNotPresent
          ports:
          - name: http
            containerPort: 8080
          command:
          - ./flagger
          - -log-level=info
          - -metrics-server=http://prometheus:9090
          - -enable-config-tracking=true
          - -slack-user=flagger
          livenessProbe:
            exec:
              command:
              - wget
              - --quiet
              - --tries=1
              - --timeout=4
              - --spider
              - http://localhost:8080/healthz
            timeoutSeconds: 5
          readinessProbe:
            exec:
              command:
              - wget
              - --quiet
              - --tries=1
              - --timeout=4
              - --spider
              - http://localhost:8080/healthz
            timeoutSeconds: 5
          resources:
            limits:
              cpu: 1000m
              memory: 512Mi
            requests:
              cpu: 10m
              memory: 32Mi
      securityContext:
        fsGroup: 10001
        runAsGroup: 10001
        runAsNonRoot: true
        runAsUser: 10001
        supplementalGroups:
        - 10001
```

Flagger is running with these settings in our environment with no problems noticable so far.