### PR TITLE
Run post-rollout hooks when skipAnalysis is true

### DIFF
--- a/pkg/controller/events_test.go
+++ b/pkg/controller/events_test.go
@@ -58,10 +58,14 @@ func TestWebhooks(t *testing.T) {
 					{Phase: flaggerv1.CanaryPhaseInitialized, Metadata: map[string]string{"eventMessage": "Confirm-rollout check confirm-rollout-webhook passed"}},
 					{Phase: flaggerv1.CanaryPhaseProgressing, Metadata: map[string]string{"eventMessage": "New revision detected! Scaling up podinfo.default"}},
 					{Phase: flaggerv1.CanaryPhaseProgressing, Metadata: map[string]string{"eventMessage": "Copying podinfo.default template spec to podinfo-primary.default"}},
+					{Phase: flaggerv1.CanaryPhaseSucceeded, Metadata: map[string]string{"eventMessage": "Post-rollout check post-rollout-webhook passed"}},
 					{Phase: flaggerv1.CanaryPhaseSucceeded, Metadata: map[string]string{"eventMessage": "Promotion completed! Canary analysis was skipped for podinfo.default"}},
 				},
 				"confirm-rollout": {
 					{Phase: flaggerv1.CanaryPhaseInitialized, Metadata: map[string]string{"eventMessage": ""}},
+				},
+				"post-rollout": {
+					{Phase: flaggerv1.CanaryPhaseSucceeded, Metadata: map[string]string{"eventMessage": ""}},
 				},
 			},
 			test: func(t *testing.T, mocks fixture) {

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -833,6 +833,7 @@ func (c *Controller) shouldSkipAnalysis(canary *flaggerv1.Canary, canaryControll
 
 	canarySucceeded := canary.DeepCopy()
 	canarySucceeded.Status.Phase = flaggerv1.CanaryPhaseSucceeded
+	c.runPostRolloutHooks(canarySucceeded, flaggerv1.CanaryPhaseSucceeded)
 	c.recordEventInfof(canarySucceeded, "Promotion completed! Canary analysis was skipped for %s.%s",
 		canary.Spec.TargetRef.Name, canary.Namespace)
 	c.alert(canarySucceeded, "Canary analysis was skipped, promotion finished.",


### PR DESCRIPTION
When `skipAnalysis: true` is configured, the canary promotion completes but post-rollout webhooks are never executed. I hit this while setting up a deployment notification pipeline.

The issue is in `shouldSkipAnalysis` - it copies the canary spec to primary, marks the canary as succeeded, but then returns without calling `runPostRolloutHooks`. The normal promotion path in the finalising phase (line 414) does call it.

The fix adds a single line to call `runPostRolloutHooks` before the success message is logged. I also updated the skip-analysis test case in `events_test.go` to verify the post-rollout webhook now fires.

Fixes #1195