### PR TITLE
fix: update init container config refs in primary spec

### DIFF
--- a/pkg/canary/config_tracker.go
+++ b/pkg/canary/config_tracker.go
@@ -78,7 +78,7 @@ func configIsDisabled(annotations map[string]string) bool {
 func (ct *ConfigTracker) getRefFromConfigMap(name string, namespace string) (*ConfigRef, error) {
 	config, err := ct.KubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("configmap  %s.%s get query error: %w", name, namespace, err)
+		return nil, fmt.Errorf("configmap %s.%s get query error: %w", name, namespace, err)
 	}
 
 	if configIsDisabled(config.GetAnnotations()) {
@@ -449,6 +449,42 @@ func (ct *ConfigTracker) ApplyPrimaryConfigs(spec corev1.PodSpec, refs map[strin
 
 	// update containers
 	for _, container := range spec.Containers {
+		// update env
+		for i, env := range container.Env {
+			if env.ValueFrom != nil {
+				switch {
+				case env.ValueFrom.ConfigMapKeyRef != nil:
+					name := fmt.Sprintf("%s/%s", ConfigRefMap, env.ValueFrom.ConfigMapKeyRef.Name)
+					if _, exists := refs[name]; exists {
+						container.Env[i].ValueFrom.ConfigMapKeyRef.Name += "-primary"
+					}
+				case env.ValueFrom.SecretKeyRef != nil:
+					name := fmt.Sprintf("%s/%s", ConfigRefSecret, env.ValueFrom.SecretKeyRef.Name)
+					if _, exists := refs[name]; exists {
+						container.Env[i].ValueFrom.SecretKeyRef.Name += "-primary"
+					}
+				}
+			}
+		}
+		// update envFrom
+		for i, envFrom := range container.EnvFrom {
+			switch {
+			case envFrom.ConfigMapRef != nil:
+				name := fmt.Sprintf("%s/%s", ConfigRefMap, envFrom.ConfigMapRef.Name)
+				if _, exists := refs[name]; exists {
+					container.EnvFrom[i].ConfigMapRef.Name += "-primary"
+				}
+			case envFrom.SecretRef != nil:
+				name := fmt.Sprintf("%s/%s", ConfigRefSecret, envFrom.SecretRef.Name)
+				if _, exists := refs[name]; exists {
+					container.EnvFrom[i].SecretRef.Name += "-primary"
+				}
+			}
+		}
+	}
+
+	// update init containers
+	for _, container := range spec.InitContainers {
 		// update env
 		for i, env := range container.Env {
 			if env.ValueFrom != nil {

--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -90,6 +90,11 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 			assert.Equal(t, configMapProjected.Data["color"], configPrimaryProjected.Data["color"])
 		}
 
+		assert.Equal(t, "podinfo-config-init-env-primary",
+			depPrimary.Spec.Template.Spec.InitContainers[0].Env[0].ValueFrom.ConfigMapKeyRef.Name)
+		assert.Equal(t, "podinfo-config-init-all-env-primary",
+			depPrimary.Spec.Template.Spec.InitContainers[0].EnvFrom[0].ConfigMapRef.Name)
+
 		_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-tracker-enabled", metav1.GetOptions{})
 		assert.NoError(t, err)
 		_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-tracker-enabled-primary", metav1.GetOptions{})
@@ -165,6 +170,11 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, configMapProjected.Data["color"], configPrimaryProjected.Data["color"])
 		}
+
+		assert.Equal(t, "podinfo-config-init-env-primary",
+			daePrimary.Spec.Template.Spec.InitContainers[0].Env[0].ValueFrom.ConfigMapKeyRef.Name)
+		assert.Equal(t, "podinfo-config-init-all-env-primary",
+			daePrimary.Spec.Template.Spec.InitContainers[0].EnvFrom[0].ConfigMapRef.Name)
 
 		_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Get(context.TODO(), "podinfo-config-tracker-enabled", metav1.GetOptions{})
 		assert.NoError(t, err)
@@ -243,6 +253,11 @@ func TestConfigTracker_Secrets(t *testing.T) {
 			assert.Equal(t, string(secretProjected.Data["apiKey"]), string(secretPrimaryProjected.Data["apiKey"]))
 		}
 
+		assert.Equal(t, "podinfo-secret-init-env-primary",
+			depPrimary.Spec.Template.Spec.InitContainers[0].Env[1].ValueFrom.SecretKeyRef.Name)
+		assert.Equal(t, "podinfo-secret-init-all-env-primary",
+			depPrimary.Spec.Template.Spec.InitContainers[0].EnvFrom[1].SecretRef.Name)
+
 		_, err = mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-tracker-enabled", metav1.GetOptions{})
 		assert.NoError(t, err)
 		_, err = mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-tracker-enabled-primary", metav1.GetOptions{})
@@ -317,6 +332,11 @@ func TestConfigTracker_Secrets(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, string(secretProjected.Data["apiKey"]), string(secretPrimaryProjected.Data["apiKey"]))
 		}
+
+		assert.Equal(t, "podinfo-secret-init-env-primary",
+			daePrimary.Spec.Template.Spec.InitContainers[0].Env[1].ValueFrom.SecretKeyRef.Name)
+		assert.Equal(t, "podinfo-secret-init-all-env-primary",
+			daePrimary.Spec.Template.Spec.InitContainers[0].EnvFrom[1].SecretRef.Name)
 
 		_, err = mocks.kubeClient.CoreV1().Secrets("default").Get(context.TODO(), "podinfo-secret-tracker-enabled", metav1.GetOptions{})
 		assert.NoError(t, err)


### PR DESCRIPTION
ApplyPrimaryConfigs rewrites ConfigMap/Secret refs in spec.Containers to use -primary copies, but skips spec.InitContainers entirely. GetTargetConfigs already tracks init container refs, so the primary copies get created, but the init containers in the primary deployment still point to the originals. Not great.

How to reproduce: deploy anything with an init container that pulls config from a ConfigMap or Secret via env/envFrom, let flagger init the primary, check the primary deployment spec - init containers still reference the original names.

Fix mirrors the existing containers loop for InitContainers. Also squashed a double-space typo in an error message while in the file.

Tests added to TestConfigTracker_ConfigMaps and TestConfigTracker_Secrets for both deployment and daemonset subtests.