### PR TITLE
Keep canary alive when primary promotion fails

### DIFF
--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -301,7 +301,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 				// instead of rolling back traffic to the unhealthy primary
 				if cd.Status.Phase == flaggerv1.CanaryPhasePromoting ||
 					cd.Status.Phase == flaggerv1.CanaryPhaseFinalising {
-					c.handleFailedPromotion(cd, canaryController, err)
+					c.handleFailedPromotion(cd, canaryController, meshRouter, err)
 				} else {
 					c.rollback(cd, canaryController, meshRouter, scalerReconciler)
 				}
@@ -997,14 +997,28 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 }
 
 // handleFailedPromotion marks the rollout as failed when the primary is unhealthy
-// during promotion, without scaling the canary down or routing to the primary.
-func (c *Controller) handleFailedPromotion(canary *flaggerv1.Canary, canaryController canary.Controller, err error) {
+// during promotion and routes all traffic back to the canary, the only healthy
+// copy of the new revision. Traffic may already have been shifted to the primary
+// by runPromotionTrafficShift, so it must be moved back explicitly.
+func (c *Controller) handleFailedPromotion(canary *flaggerv1.Canary, canaryController canary.Controller,
+	meshRouter router.Interface, err error) {
 	c.recordEventWarningf(canary, "Promotion of %s.%s failed, primary not ready: %v",
 		canary.Spec.TargetRef.Name, canary.Namespace, err)
 	c.alert(canary, fmt.Sprintf("Promotion failed, primary not ready: %v", err),
 		false, flaggerv1.SeverityError)
 
-	if err := canaryController.SetStatusPhase(canary, flaggerv1.CanaryPhaseFailed); err != nil {
+	// route all traffic to the canary, off the unhealthy primary
+	primaryWeight := 0
+	canaryWeight := c.totalWeight(canary)
+	if err := meshRouter.SetRoutes(canary, primaryWeight, canaryWeight, false); err != nil {
+		c.recordEventWarningf(canary, "%v", err)
+		return
+	}
+	c.recorder.SetWeight(canary, primaryWeight, canaryWeight)
+
+	// mark as failed while reporting the weight that matches the routing
+	if err := canaryController.SyncStatus(canary, flaggerv1.CanaryStatus{
+		Phase: flaggerv1.CanaryPhaseFailed, CanaryWeight: canaryWeight}); err != nil {
 		c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).Errorf("%v", err)
 		return
 	}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -297,7 +297,14 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 		if err != nil {
 			c.recordEventWarningf(cd, "%v", err)
 			if !retriable {
-				c.rollback(cd, canaryController, meshRouter, scalerReconciler)
+				// during promotion the canary is the only healthy copy, halt
+				// instead of rolling back traffic to the unhealthy primary
+				if cd.Status.Phase == flaggerv1.CanaryPhasePromoting ||
+					cd.Status.Phase == flaggerv1.CanaryPhaseFinalising {
+					c.handleFailedPromotion(cd, canaryController, err)
+				} else {
+					c.rollback(cd, canaryController, meshRouter, scalerReconciler)
+				}
 			}
 			return
 		}
@@ -975,6 +982,29 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 
 	// mark canary as failed
 	if err := canaryController.SyncStatus(canary, flaggerv1.CanaryStatus{Phase: flaggerv1.CanaryPhaseFailed, CanaryWeight: 0}); err != nil {
+		c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).Errorf("%v", err)
+		return
+	}
+
+	c.recorder.SetStatus(canary, flaggerv1.CanaryPhaseFailed)
+	c.recorder.IncFailures(metrics.CanaryMetricLabels{
+		Name:               canary.Spec.TargetRef.Name,
+		Namespace:          canary.Namespace,
+		DeploymentStrategy: canary.DeploymentStrategy(),
+		AnalysisStatus:     metrics.AnalysisStatusCompleted,
+	})
+	c.runPostRolloutHooks(canary, flaggerv1.CanaryPhaseFailed)
+}
+
+// handleFailedPromotion marks the rollout as failed when the primary is unhealthy
+// during promotion, without scaling the canary down or routing to the primary.
+func (c *Controller) handleFailedPromotion(canary *flaggerv1.Canary, canaryController canary.Controller, err error) {
+	c.recordEventWarningf(canary, "Promotion of %s.%s failed, primary not ready: %v",
+		canary.Spec.TargetRef.Name, canary.Namespace, err)
+	c.alert(canary, fmt.Sprintf("Promotion failed, primary not ready: %v", err),
+		false, flaggerv1.SeverityError)
+
+	if err := canaryController.SetStatusPhase(canary, flaggerv1.CanaryPhaseFailed); err != nil {
 		c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).Errorf("%v", err)
 		return
 	}

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -82,6 +82,39 @@ func (f fixture) makeReady(t *testing.T, name string) {
 	require.NoError(t, err)
 }
 
+// makePrimaryNotReady puts the primary into a stuck rollout (progress deadline exceeded).
+func (f fixture) makePrimaryNotReady(t *testing.T) {
+	primaryName := fmt.Sprintf("%s-primary", f.canary.Spec.TargetRef.Name)
+	p, err := f.kubeClient.AppsV1().
+		Deployments("default").
+		Get(context.TODO(), primaryName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	p.Status = appsv1.DeploymentStatus{
+		ObservedGeneration: p.Generation,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+		ReadyReplicas:      0,
+		AvailableReplicas:  0,
+		Conditions: []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionFalse,
+				Reason: "ProgressDeadlineExceeded",
+			},
+			{
+				Type:           appsv1.DeploymentAvailable,
+				Status:         corev1.ConditionFalse,
+				Reason:         "MinimumReplicasUnavailable",
+				LastUpdateTime: metav1.Now(),
+			},
+		},
+	}
+
+	_, err = f.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), p, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
 func newDeploymentFixture(c *flaggerv1.Canary) fixture {
 	if c == nil {
 		c = newDeploymentTestCanary()

--- a/pkg/controller/scheduler_deployment_test.go
+++ b/pkg/controller/scheduler_deployment_test.go
@@ -165,16 +165,76 @@ func TestScheduler_DeploymentPromotionPrimaryNotReady(t *testing.T) {
 	require.NotNil(t, canaryDep.Spec.Replicas)
 	assert.Equal(t, canaryReplicas, *canaryDep.Spec.Replicas, "canary must not be scaled to zero when promotion fails")
 
-	// traffic must NOT be shifted entirely onto the broken primary
+	// traffic must be routed to the healthy canary, off the broken primary
 	primaryWeight, canaryWeight, _, err := mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
-	assert.NotEqual(t, 100, primaryWeight, "traffic must not be routed entirely to the unhealthy primary")
-	assert.Greater(t, canaryWeight, 0, "canary must keep serving traffic when promotion fails")
+	assert.Equal(t, 0, primaryWeight, "no traffic must remain on the unhealthy primary")
+	assert.Equal(t, 100, canaryWeight, "all traffic must be routed to the healthy canary")
 
 	// the rollout is reported as failed so it stops advancing and alerts
 	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, flaggerv1.CanaryPhaseFailed, c.Status.Phase)
+	assert.Equal(t, 100, c.Status.CanaryWeight, "reported canary weight must match the traffic on the canary")
+}
+
+// when the primary fails after promotion traffic has already been shifted to it
+// (Finalising phase), traffic must be routed back to the healthy canary (#1898)
+func TestScheduler_DeploymentPromotionFailedAfterTrafficShift(t *testing.T) {
+	mocks := newDeploymentFixture(nil)
+
+	// initializing
+	mocks.ctrl.advanceCanary("podinfo", "default")
+	mocks.makePrimaryReady(t)
+
+	// initialized
+	mocks.ctrl.advanceCanary("podinfo", "default")
+
+	// update
+	dep2 := newDeploymentTestDeploymentV2()
+	_, err := mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// detect changes -> progressing, canary scaled up
+	mocks.ctrl.advanceCanary("podinfo", "default")
+	mocks.makeCanaryReady(t)
+
+	canaryDep, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, canaryDep.Spec.Replicas)
+	canaryReplicas := *canaryDep.Spec.Replicas
+	require.Greater(t, canaryReplicas, int32(0))
+
+	// simulate: promotion already shifted all traffic to the primary (Finalising)
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	err = mocks.deployer.SetStatusPhase(cd, flaggerv1.CanaryPhaseFinalising)
+	require.NoError(t, err)
+	require.NoError(t, mocks.router.SetRoutes(mocks.canary, 100, 0, false))
+
+	// the promoted primary then fails to stay ready
+	mocks.makePrimaryNotReady(t)
+
+	// advance: Flagger observes the primary is stuck
+	mocks.ctrl.advanceCanary("podinfo", "default")
+
+	// traffic must be routed back to the healthy canary, off the broken primary
+	primaryWeight, canaryWeight, _, err := mocks.router.GetRoutes(mocks.canary)
+	require.NoError(t, err)
+	assert.Equal(t, 0, primaryWeight, "no traffic must remain on the unhealthy primary")
+	assert.Equal(t, 100, canaryWeight, "all traffic must be routed to the healthy canary")
+
+	// the canary must not be scaled to zero
+	canaryDep, err = mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, canaryDep.Spec.Replicas)
+	assert.Equal(t, canaryReplicas, *canaryDep.Spec.Replicas, "canary must not be scaled to zero when promotion fails")
+
+	// reported canary weight must match the routing (not zeroed)
+	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, flaggerv1.CanaryPhaseFailed, c.Status.Phase)
+	assert.Equal(t, 100, c.Status.CanaryWeight, "reported canary weight must match the traffic on the canary")
 }
 
 func TestScheduler_DeploymentSkipAnalysis(t *testing.T) {

--- a/pkg/controller/scheduler_deployment_test.go
+++ b/pkg/controller/scheduler_deployment_test.go
@@ -116,6 +116,67 @@ func TestScheduler_DeploymentRollback(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhaseFailed, c.Status.Phase)
 }
 
+// when the primary fails to become ready during promotion, the healthy canary
+// must be kept instead of rolled back to the broken primary (#1898)
+func TestScheduler_DeploymentPromotionPrimaryNotReady(t *testing.T) {
+	mocks := newDeploymentFixture(nil)
+
+	// initializing
+	mocks.ctrl.advanceCanary("podinfo", "default")
+	mocks.makePrimaryReady(t)
+
+	// initialized
+	mocks.ctrl.advanceCanary("podinfo", "default")
+
+	// update
+	dep2 := newDeploymentTestDeploymentV2()
+	_, err := mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep2, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// detect changes -> progressing, canary scaled up
+	mocks.ctrl.advanceCanary("podinfo", "default")
+	mocks.makeCanaryReady(t)
+	require.NoError(t, assertPhase(mocks.flaggerClient, "podinfo", flaggerv1.CanaryPhaseProgressing))
+
+	canaryDep, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, canaryDep.Spec.Replicas)
+	canaryReplicas := *canaryDep.Spec.Replicas
+	require.Greater(t, canaryReplicas, int32(0))
+
+	// simulate: analysis succeeded, spec promoted to primary, now finishing promotion
+	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	err = mocks.deployer.SetStatusPhase(cd, flaggerv1.CanaryPhasePromoting)
+	require.NoError(t, err)
+
+	// known routing state at promotion time (split between primary and canary)
+	require.NoError(t, mocks.router.SetRoutes(mocks.canary, 50, 50, false))
+
+	// the promoted primary fails to roll out
+	mocks.makePrimaryNotReady(t)
+
+	// advance: Flagger observes the primary is stuck
+	mocks.ctrl.advanceCanary("podinfo", "default")
+
+	// the canary must NOT be scaled to zero - it is the only healthy copy serving traffic
+	canaryDep, err = mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, canaryDep.Spec.Replicas)
+	assert.Equal(t, canaryReplicas, *canaryDep.Spec.Replicas, "canary must not be scaled to zero when promotion fails")
+
+	// traffic must NOT be shifted entirely onto the broken primary
+	primaryWeight, canaryWeight, _, err := mocks.router.GetRoutes(mocks.canary)
+	require.NoError(t, err)
+	assert.NotEqual(t, 100, primaryWeight, "traffic must not be routed entirely to the unhealthy primary")
+	assert.Greater(t, canaryWeight, 0, "canary must keep serving traffic when promotion fails")
+
+	// the rollout is reported as failed so it stops advancing and alerts
+	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, flaggerv1.CanaryPhaseFailed, c.Status.Phase)
+}
+
 func TestScheduler_DeploymentSkipAnalysis(t *testing.T) {
 	mocks := newDeploymentFixture(nil)
 	// initializing


### PR DESCRIPTION
## Problem

Reported in #1898. When a primary pod fails to initialize *after* a canary
promotion, Flagger takes the application down instead of preserving the
healthy canary.

Flow:

1. The canary analysis succeeds and Flagger copies the canary pod spec to the
   primary (`Promote`), then moves to the `Promoting`/`Finalising` phase and
   waits for the primary rollout to finish.
2. The promoted primary fails to become ready (bad image, failing sidecar,
   slow/again-failing init, etc.).
3. `IsPrimaryReady` eventually returns a non-retriable error (progress deadline
   exceeded), which triggered the standard analysis `rollback()`.
4. `rollback()` routes **all** traffic to the primary and scales the canary to
   **zero**.

The problem is that during promotion the primary already runs the new
(failing) spec, while the canary is the only healthy copy of the new revision
still serving traffic. "Rolling back to the primary" therefore sends all
traffic to the broken primary and deletes the only working pods — a full
outage (worst in `Recreate` mode, where no old primary pod remains).

`rollback()` is correct for an analysis failure during `Progressing` (there the
primary still holds the old, good spec), but wrong once promotion has started.

## Fix

When `IsPrimaryReady` returns a non-retriable error **and** the canary is in the
`Promoting` or `Finalising` phase, halt the promotion instead of rolling back:

- mark the rollout as `Failed` and emit a warning event + alert, so it stops
  advancing and surfaces the failure;
- **do not** route traffic to the unhealthy primary;
- **do not** scale the canary to zero.

The canary keeps serving traffic until the primary recovers or a corrected
revision is applied. Behaviour during `Progressing` (and every other phase) is
unchanged.

This is the minimal, non-destructive safety fix. Follow-up #1932 tracks the
model-correct behaviour — note that a promotion only starts after the canary
passes analysis, so the canary running the new revision is healthy and only the
primary's separately-rendered copy failed; whether Flagger should revert the
primary to its last-known-good spec or keep serving the healthy canary is an
open question to settle there.

## Tests

Added `TestScheduler_DeploymentPromotionPrimaryNotReady`, which drives the
canary to `Promoting`, makes the primary stuck (`ProgressDeadlineExceeded`),
and asserts the canary is not scaled to zero and traffic is not shifted onto
the broken primary. The full `pkg/controller` and `pkg/canary` suites pass
(`go test ./pkg/controller/ ./pkg/canary/`), `gofmt` and `go vet` are clean.

Fixes #1898
