### PR TITLE
chore: upgrade signalflow-client-go to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/signalfx/signalflow-client-go v0.1.0
+	github.com/signalfx/signalflow-client-go/v2 v2.3.0
 	github.com/signalfx/signalfx-go v1.57.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7D
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/signalfx/signalflow-client-go v0.1.0 h1:aqyt+st3/y8x8JtuwYRL9pOkOTJb+KeCoRWi0SuY5vw=
-github.com/signalfx/signalflow-client-go v0.1.0/go.mod h1:mY4DTAZuLHyMNGBjSrNdCg5kUU0hSkYjukAnjsVbsQs=
+github.com/signalfx/signalflow-client-go/v2 v2.3.0 h1:CMhvEfDDWbdPCfMNiQTAymRIRzVbgveGbTq5wr8OHuM=
+github.com/signalfx/signalflow-client-go/v2 v2.3.0/go.mod h1:ir6CHksVkhh1vlslldjf6k5qD88QQxWW8WMG5PxSQco=
 github.com/signalfx/signalfx-go v1.57.0 h1:Z+d/TJ/EVxkg46aP2lhAr5ft+EqwXb2nRmLvP+yJ1Sk=
 github.com/signalfx/signalfx-go v1.57.0/go.mod h1:CHt+/W1qd62tXxNqG7ZUB9pEsEAOD6tuvdlyDNIOO1s=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/pkg/metrics/providers/splunk.go
+++ b/pkg/metrics/providers/splunk.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow"
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 )
@@ -54,15 +54,14 @@ type SplunkProvider struct {
 	fromDelta int64
 }
 
-type splunkResponse struct {
-}
+type splunkResponse struct{}
 
 // NewSplunkProvider takes a canary spec, a provider spec and the credentials map, and
 // returns a Splunk client ready to execute queries against the API
 func NewSplunkProvider(metricInterval string,
 	provider flaggerv1.MetricTemplateProvider,
-	credentials map[string][]byte) (*SplunkProvider, error) {
-
+	credentials map[string][]byte,
+) (*SplunkProvider, error) {
 	address := provider.Address
 	if address == "" {
 		return nil, fmt.Errorf("splunk endpoint is not set")

--- a/pkg/metrics/providers/splunk_test.go
+++ b/pkg/metrics/providers/splunk_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow"
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,7 +77,8 @@ func TestSplunkProvider_RunQuery(t *testing.T) {
 		parsedUrl, err := url.Parse(fakeBackend.URL())
 		require.NoError(t, err)
 
-		sp, err := NewSplunkProvider("1m",
+		sp, err := NewSplunkProvider(
+			"1m",
 			flaggerv1.MetricTemplateProvider{Address: fmt.Sprintf("http://%s", parsedUrl.Host)},
 			map[string][]byte{
 				signalFxTokenSecretKey: []byte(fakeBackend.AccessToken),
@@ -110,7 +111,8 @@ func TestSplunkProvider_RunQuery(t *testing.T) {
 		parsedUrl, err := url.Parse(fakeBackend.URL())
 		require.NoError(t, err)
 
-		sp, err := NewSplunkProvider("1m",
+		sp, err := NewSplunkProvider(
+			"1m",
 			flaggerv1.MetricTemplateProvider{Address: fmt.Sprintf("http://%s", parsedUrl.Host)},
 			map[string][]byte{
 				signalFxTokenSecretKey: []byte(fakeBackend.AccessToken),
@@ -141,7 +143,8 @@ func TestSplunkProvider_RunQuery(t *testing.T) {
 		parsedUrl, err := url.Parse(fakeBackend.URL())
 		require.NoError(t, err)
 
-		sp, err := NewSplunkProvider("1m",
+		sp, err := NewSplunkProvider(
+			"1m",
 			flaggerv1.MetricTemplateProvider{Address: fmt.Sprintf("http://%s", parsedUrl.Host)},
 			map[string][]byte{
 				signalFxTokenSecretKey: []byte(fakeBackend.AccessToken),
@@ -169,7 +172,8 @@ func TestSplunkProvider_IsOnline(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			sp, err := NewSplunkProvider("1m",
+			sp, err := NewSplunkProvider(
+				"1m",
 				flaggerv1.MetricTemplateProvider{Address: ts.URL},
 				map[string][]byte{
 					signalFxTokenSecretKey: []byte(token),


### PR DESCRIPTION
Upgrade SignalFx SignalFlow client dependency `github.com/signalfx/signalflow-client-go` to `v2`. 