### PR TITLE
fix: return finalizer readiness errors

### DIFF
--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -80,7 +80,7 @@ func (c *Controller) finalize(old interface{}) error {
 		Cap:      canary.GetAnalysisInterval(),
 		Steps:    4,
 	}
-	retry.OnError(backoff, func(err error) bool {
+	err = retry.OnError(backoff, func(err error) bool {
 		return err.Error() == "retriable error"
 	}, func() error {
 		retriable, err := canaryController.IsCanaryReady(canary)

--- a/pkg/controller/finalizer_test.go
+++ b/pkg/controller/finalizer_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTesting "k8s.io/client-go/testing"
 
@@ -103,4 +106,30 @@ func TestFinalizer_removeFinalizer(t *testing.T) {
 			require.Nil(t, err)
 		}
 	}
+}
+
+func TestFinalizer_finalizeReturnsReadinessError(t *testing.T) {
+	mocks := newDeploymentFixture(nil)
+	mocks.canary.Spec.Provider = flaggerv1.KubernetesProvider
+
+	dep, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	dep.Status = appsv1.DeploymentStatus{
+		ObservedGeneration: dep.Generation,
+		Conditions: []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentProgressing,
+				Status: "False",
+				Reason: "ProgressDeadlineExceeded",
+			},
+		},
+	}
+
+	_, err = mocks.kubeClient.AppsV1().Deployments("default").Update(context.TODO(), dep, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = mocks.ctrl.finalize(mocks.canary)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "canary not ready during finalizing")
 }


### PR DESCRIPTION
Related: #1550, #1562

`retry.OnError(...)` was already used in the finalizer readiness check, but the returned error got dropped. If the target Deployment hits `ProgressDeadlineExceeded`, finalization still keeps going anyway, kinda rough.

This stores that error and stops finalization until the target is ready. Added a regression test for the stuck Deployment case.

Repro
1. Create a Canary with `revertOnDeletion: true`.
2. Delete it while the target Deployment reports `Progressing=False` and `Reason=ProgressDeadlineExceeded`.
3. On `main`, `finalize()` returns `nil` and finalization completes.
4. With this patch, Flagger returns `canary not ready during finalizing` and retries later.

Tested with `go test ./...`.
