### PR TITLE
fix: reconcile service trafficDistribution updates

### DIFF
--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -206,9 +206,11 @@ func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, nam
 
 		portsDiff := cmp.Diff(svcSpec.Ports, svc.Spec.Ports, cmpopts.SortSlices(sortPorts))
 		selectorsDiff := cmp.Diff(svcSpec.Selector, svc.Spec.Selector)
-		if portsDiff != "" || selectorsDiff != "" {
+		trafficDistributionDiff := cmp.Diff(svcSpec.TrafficDistribution, svc.Spec.TrafficDistribution)
+		if portsDiff != "" || selectorsDiff != "" || trafficDistributionDiff != "" {
 			svcClone.Spec.Ports = svcSpec.Ports
 			svcClone.Spec.Selector = svcSpec.Selector
+			svcClone.Spec.TrafficDistribution = svcSpec.TrafficDistribution
 			updateService = true
 		}
 

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -97,6 +97,51 @@ func TestServiceRouter_TrafficDistribution(t *testing.T) {
 	assert.Equal(t, trafficDistribution, *apexSvc.Spec.TrafficDistribution)
 }
 
+func TestServiceRouter_UpdateTrafficDistribution(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &KubernetesDefaultRouter{
+		kubeClient:    mocks.kubeClient,
+		flaggerClient: mocks.flaggerClient,
+		logger:        mocks.logger,
+	}
+
+	err := router.Initialize(mocks.canary)
+	require.NoError(t, err)
+
+	err = router.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	canary, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	canaryClone := canary.DeepCopy()
+	trafficDistribution := "PreferClose"
+	canaryClone.Spec.Service.TrafficDistribution = trafficDistribution
+
+	updatedCanary, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(context.TODO(), canaryClone, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = router.Initialize(updatedCanary)
+	require.NoError(t, err)
+	err = router.Reconcile(updatedCanary)
+	require.NoError(t, err)
+
+	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-canary", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, canarySvc.Spec.TrafficDistribution)
+	assert.Equal(t, trafficDistribution, *canarySvc.Spec.TrafficDistribution)
+
+	primarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, primarySvc.Spec.TrafficDistribution)
+	assert.Equal(t, trafficDistribution, *primarySvc.Spec.TrafficDistribution)
+
+	apexSvc, err := mocks.kubeClient.CoreV1().Services("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, apexSvc.Spec.TrafficDistribution)
+	assert.Equal(t, trafficDistribution, *apexSvc.Spec.TrafficDistribution)
+}
+
 func TestServiceRouter_Update(t *testing.T) {
 	mocks := newFixture(nil)
 	router := &KubernetesDefaultRouter{


### PR DESCRIPTION
Follow-up to #1844.

If `spec.service.trafficDistribution` is added or changed after Flagger already created the Services, reconcile leaves `podinfo`, `podinfo-primary`, and `podinfo-canary` stale. The field just stays unset, kinda annoying.

This patch updates `Service.spec.trafficDistribution` during reconcile, so existing Services match the Canary spec too.

Repro:
1. Create a Canary without `spec.service.trafficDistribution`.
2. Let Flagger create the Services.
3. Update the Canary and set `spec.service.trafficDistribution: PreferClose`.
4. Before this patch, all 3 Services still keep `spec.trafficDistribution` empty.

Checks:
- `go test ./pkg/router -run TestServiceRouter_UpdateTrafficDistribution -count=1`
- `go test ./...`