### PR TITLE
Exclude linkerd-proxy sidecar ports from port discovery

### DIFF
--- a/pkg/canary/util.go
+++ b/pkg/canary/util.go
@@ -29,8 +29,9 @@ import (
 )
 
 var sidecars = map[string]bool{
-	"istio-proxy": true,
-	"envoy":       true,
+	"istio-proxy":   true,
+	"envoy":         true,
+	"linkerd-proxy": true,
 }
 
 func getPorts(cd *flaggerv1.Canary, cs []corev1.Container) map[string]int32 {

--- a/pkg/canary/util_test.go
+++ b/pkg/canary/util_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 )
 
 func TestIncludeLabelsByPrefix(t *testing.T) {
@@ -67,6 +70,43 @@ func TestIncludeLabelsNoIncludes(t *testing.T) {
 	filteredLabels := includeLabelsByPrefix(labels, includeLabelPrefix)
 
 	assert.Equal(t, map[string]string{}, filteredLabels)
+}
+
+func TestGetPortsExcludesSidecars(t *testing.T) {
+	cd := &flaggerv1.Canary{
+		Spec: flaggerv1.CanarySpec{
+			Service: flaggerv1.CanaryService{
+				Port: 8080,
+			},
+		},
+	}
+
+	containers := []corev1.Container{
+		{
+			Name: "app",
+			Ports: []corev1.ContainerPort{
+				{Name: "http", ContainerPort: 8080},
+				{Name: "metrics", ContainerPort: 9090},
+			},
+		},
+		{
+			Name: "linkerd-proxy",
+			Ports: []corev1.ContainerPort{
+				{Name: "linkerd-proxy", ContainerPort: 4143},
+				{Name: "linkerd-admin", ContainerPort: 4191},
+			},
+		},
+		{
+			Name: "istio-proxy",
+			Ports: []corev1.ContainerPort{
+				{Name: "istio-proxy", ContainerPort: 15090},
+			},
+		},
+	}
+
+	ports := getPorts(cd, containers)
+
+	assert.Equal(t, map[string]int32{"metrics": 9090}, ports)
 }
 
 func TestMakePrimaryLabels(t *testing.T) {


### PR DESCRIPTION
Motivation:
When canary.spec.service.portDiscovery is enabled, Flagger scans the
target Deployment/DaemonSet containers and adds any extra container
ports to the generated canary/primary/apex Services, so multi-port
apps stay reachable. The exclusion list used to skip mesh sidecars
only knew about Istio's container names ("istio-proxy", "envoy").
Linkerd's proxy injector uses the container name "linkerd-proxy", so
its internal ports (e.g. 4143 inbound, 4191 admin) were treated as
application ports and added to the generated Services instead of
being skipped. This was reported as a comment on #1345: "portDiscovery
does not work for linkerd" (using portDiscovery on a linkerd-meshed
deployment).

Note this does not address the original report in #1345, which does
not enable portDiscovery at all — dropping ports that only exist on a
pre-existing Service (and are not declared as container ports) is a
separate, broader problem that needs its own design discussion.

Approach:
Add "linkerd-proxy" to the sidecars exclusion map in
pkg/canary/util.go, matching how "istio-proxy" and "envoy" are
already excluded from getPorts().

Validation:
Added TestGetPortsExcludesSidecars to pkg/canary/util_test.go,
asserting that getPorts() drops linkerd-proxy and istio-proxy
container ports while keeping a regular app container's extra port.

  go build ./...
  go test ./pkg/canary/... -run TestGetPortsExcludesSidecars -v

Both passed. Also ran the full pkg/canary test suite (go test
./pkg/canary/...) with no regressions.

Fixes #1345

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>