### PR TITLE
metrics: add canary label to metrics and clean up stale series on canary/namespace removal

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -64,6 +64,10 @@ type Controller struct {
 	logger               *zap.SugaredLogger
 	canaries             *sync.Map
 	jobs                 map[string]CanaryJob
+	// namespaces we have previously reported a canary_total value for;
+	// used to remove stale per-namespace series when a namespace no
+	// longer contains any Canary resources.
+	trackedNamespaces    map[string]struct{}
 	recorder             metrics.Recorder
 	notifier             notifier.Interface
 	canaryFactory        *canary.Factory
@@ -123,6 +127,7 @@ func NewController(
 		logger:               logger,
 		canaries:             new(sync.Map),
 		jobs:                 map[string]CanaryJob{},
+		trackedNamespaces:    map[string]struct{}{},
 		flaggerWindow:        flaggerWindow,
 		observerFactory:      observerFactory,
 		recorder:             recorder,
@@ -180,6 +185,7 @@ func NewController(
 			if ok {
 				ctrl.logger.Infof("Deleting %s.%s from cache", r.Name, r.Namespace)
 				ctrl.canaries.Delete(fmt.Sprintf("%s.%s", r.Name, r.Namespace))
+				ctrl.recorder.DeleteFor(r.Name, r.Namespace)
 			}
 		},
 	})

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -297,6 +297,12 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 	if !shouldAdvance {
 		c.recorder.SetStatus(cd, cd.Status.Phase)
+		// keep the weight gauge populated in steady state (e.g. after a
+		// controller restart or right after initialization), otherwise it
+		// is only emitted once a canary starts progressing
+		if primaryWeight, canaryWeight, _, err := meshRouter.GetRoutes(cd); err == nil {
+			c.recorder.SetWeight(cd, primaryWeight, canaryWeight)
+		}
 		return
 	}
 

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -421,6 +421,7 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 		c.recorder.SetStatus(cd, flaggerv1.CanaryPhaseSucceeded)
 		c.recorder.IncSuccesses(metrics.CanaryMetricLabels{
+			Canary:             cd.Name,
 			Name:               cd.Spec.TargetRef.Name,
 			Namespace:          cd.Namespace,
 			DeploymentStrategy: cd.DeploymentStrategy(),
@@ -843,6 +844,7 @@ func (c *Controller) shouldSkipAnalysis(canary *flaggerv1.Canary, canaryControll
 	// notify
 	c.recorder.SetStatus(canary, flaggerv1.CanaryPhaseSucceeded)
 	c.recorder.IncSuccesses(metrics.CanaryMetricLabels{
+		Canary:             canary.Name,
 		Name:               canary.Spec.TargetRef.Name,
 		Namespace:          canary.Namespace,
 		DeploymentStrategy: canary.DeploymentStrategy(),
@@ -1000,6 +1002,7 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 
 	c.recorder.SetStatus(canary, flaggerv1.CanaryPhaseFailed)
 	c.recorder.IncFailures(metrics.CanaryMetricLabels{
+		Canary:             canary.Name,
 		Name:               canary.Spec.TargetRef.Name,
 		Namespace:          canary.Namespace,
 		DeploymentStrategy: canary.DeploymentStrategy(),
@@ -1037,6 +1040,7 @@ func (c *Controller) handleFailedPromotion(canary *flaggerv1.Canary, canaryContr
 
 	c.recorder.SetStatus(canary, flaggerv1.CanaryPhaseFailed)
 	c.recorder.IncFailures(metrics.CanaryMetricLabels{
+		Canary:             canary.Name,
 		Name:               canary.Spec.TargetRef.Name,
 		Namespace:          canary.Namespace,
 		DeploymentStrategy: canary.DeploymentStrategy(),

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -153,6 +153,17 @@ func (c *Controller) scheduleCanaries() {
 	for k, v := range stats {
 		c.recorder.SetTotal(k, v)
 	}
+
+	// remove canary_total series for namespaces that no longer contain any canaries
+	for ns := range c.trackedNamespaces {
+		if _, ok := stats[ns]; !ok {
+			c.recorder.DeleteTotalFor(ns)
+			delete(c.trackedNamespaces, ns)
+		}
+	}
+	for ns := range stats {
+		c.trackedNamespaces[ns] = struct{}{}
+	}
 }
 
 func (c *Controller) advanceCanary(name string, namespace string) {

--- a/pkg/controller/scheduler_metrics_test.go
+++ b/pkg/controller/scheduler_metrics_test.go
@@ -306,6 +306,30 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		successCount := testutil.ToFloat64(mocks.ctrl.recorder.GetSuccessesMetric().WithLabelValues("podinfo", "podinfo", "default", "canary", "skipped"))
 		assert.Equal(t, float64(1), successCount)
 	})
+
+	t.Run("weight is emitted for an initialized canary before progression", func(t *testing.T) {
+		mocks := newDeploymentFixture(nil)
+
+		// drive the canary to the Initialized phase
+		mocks.ctrl.advanceCanary("podinfo", "default")
+		mocks.makePrimaryReady(t)
+		mocks.ctrl.advanceCanary("podinfo", "default")
+
+		c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, flaggerv1.CanaryPhaseInitialized, c.Status.Phase)
+
+		// a steady-state reconcile (no changes, shouldAdvance == false) must still
+		// populate the weight gauge, otherwise it is absent until the canary progresses
+		mocks.ctrl.advanceCanary("podinfo", "default")
+
+		assert.Equal(t, 2, testutil.CollectAndCount(mocks.ctrl.recorder.GetWeightMetric(), "flagger_canary_weight"))
+
+		primaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo-primary", "default"))
+		canaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo", "default"))
+		assert.Equal(t, float64(100), primaryWeight)
+		assert.Equal(t, float64(0), canaryWeight)
+	})
 }
 
 func TestController_AnalysisMetricsRecording(t *testing.T) {

--- a/pkg/controller/scheduler_metrics_test.go
+++ b/pkg/controller/scheduler_metrics_test.go
@@ -194,7 +194,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		mocks.makePrimaryReady(t)
 		mocks.ctrl.advanceCanary("podinfo", "default")
 
-		actualStatus := testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "default"))
+		actualStatus := testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "podinfo", "default"))
 		assert.Equal(t, float64(1), actualStatus)
 
 		actualTotal := testutil.ToFloat64(mocks.ctrl.recorder.GetTotalMetric().WithLabelValues("default"))
@@ -207,7 +207,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		mocks.makeCanaryReady(t)
 		mocks.ctrl.advanceCanary("podinfo", "default")
 
-		actualStatus = testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "default"))
+		actualStatus = testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "podinfo", "default"))
 		assert.Equal(t, float64(0), actualStatus)
 
 		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo-primary", "default"))
@@ -232,7 +232,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 			}
 		}
 
-		successCount := testutil.ToFloat64(mocks.ctrl.recorder.GetSuccessesMetric().WithLabelValues("podinfo", "default", "canary", "completed"))
+		successCount := testutil.ToFloat64(mocks.ctrl.recorder.GetSuccessesMetric().WithLabelValues("podinfo", "podinfo", "default", "canary", "completed"))
 		assert.Equal(t, float64(1), successCount)
 	})
 
@@ -267,7 +267,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		mocks.ctrl.advanceCanary("podinfo", "default")
 		mocks.ctrl.advanceCanary("podinfo", "default")
 
-		actualStatus := testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "default"))
+		actualStatus := testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "podinfo", "default"))
 		assert.Equal(t, float64(2), actualStatus)
 
 		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo-primary", "default"))
@@ -275,7 +275,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		assert.Equal(t, float64(100), actualPrimaryWeight)
 		assert.Equal(t, float64(0), actualCanaryWeight)
 
-		failureCount := testutil.ToFloat64(mocks.ctrl.recorder.GetFailuresMetric().WithLabelValues("podinfo", "default", "canary", "completed"))
+		failureCount := testutil.ToFloat64(mocks.ctrl.recorder.GetFailuresMetric().WithLabelValues("podinfo", "podinfo", "default", "canary", "completed"))
 		assert.Equal(t, float64(1), failureCount)
 	})
 
@@ -303,7 +303,7 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		mocks.makeCanaryReady(t)
 		mocks.ctrl.advanceCanary("podinfo", "default")
 
-		successCount := testutil.ToFloat64(mocks.ctrl.recorder.GetSuccessesMetric().WithLabelValues("podinfo", "default", "canary", "skipped"))
+		successCount := testutil.ToFloat64(mocks.ctrl.recorder.GetSuccessesMetric().WithLabelValues("podinfo", "podinfo", "default", "canary", "skipped"))
 		assert.Equal(t, float64(1), successCount)
 	})
 }
@@ -347,10 +347,10 @@ func TestController_AnalysisMetricsRecording(t *testing.T) {
 		result := mocks.ctrl.runMetricChecks(canary)
 		assert.True(t, result)
 
-		successRateMetric := mocks.ctrl.recorder.GetAnalysisMetric().WithLabelValues("podinfo", "default", "request-success-rate")
+		successRateMetric := mocks.ctrl.recorder.GetAnalysisMetric().WithLabelValues("podinfo", "podinfo", "default", "request-success-rate")
 		assert.NotNil(t, successRateMetric)
 
-		durationMetric := mocks.ctrl.recorder.GetAnalysisMetric().WithLabelValues("podinfo", "default", "request-duration")
+		durationMetric := mocks.ctrl.recorder.GetAnalysisMetric().WithLabelValues("podinfo", "podinfo", "default", "request-duration")
 		assert.NotNil(t, durationMetric)
 	})
 }

--- a/pkg/controller/scheduler_metrics_test.go
+++ b/pkg/controller/scheduler_metrics_test.go
@@ -210,8 +210,8 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		actualStatus = testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "default"))
 		assert.Equal(t, float64(0), actualStatus)
 
-		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo-primary", "default"))
-		actualCanaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "default"))
+		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo-primary", "default"))
+		actualCanaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo", "default"))
 
 		t.Logf("Progression weights - Primary: %f, Canary: %f", actualPrimaryWeight, actualCanaryWeight)
 		assert.GreaterOrEqual(t, actualPrimaryWeight, float64(50))
@@ -270,8 +270,8 @@ func TestController_MetricsStateTransition(t *testing.T) {
 		actualStatus := testutil.ToFloat64(mocks.ctrl.recorder.GetStatusMetric().WithLabelValues("podinfo", "default"))
 		assert.Equal(t, float64(2), actualStatus)
 
-		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo-primary", "default"))
-		actualCanaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "default"))
+		actualPrimaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo-primary", "default"))
+		actualCanaryWeight := testutil.ToFloat64(mocks.ctrl.recorder.GetWeightMetric().WithLabelValues("podinfo", "podinfo", "default"))
 		assert.Equal(t, float64(100), actualPrimaryWeight)
 		assert.Equal(t, float64(0), actualCanaryWeight)
 

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -94,7 +94,7 @@ func NewRecorder(controller string, register bool) Recorder {
 		Subsystem: controller,
 		Name:      "canary_weight",
 		Help:      "The virtual service destination weight current value",
-	}, []string{"workload", "namespace"})
+	}, []string{"name", "workload", "namespace"})
 
 	analysis := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
@@ -172,8 +172,8 @@ func (cr *Recorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.CanaryPhase)
 
 // SetWeight sets the weight values for primary and canary destinations
 func (cr *Recorder) SetWeight(cd *flaggerv1.Canary, primary int, canary int) {
-	cr.weight.WithLabelValues(fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name), cd.Namespace).Set(float64(primary))
-	cr.weight.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace).Set(float64(canary))
+	cr.weight.WithLabelValues(cd.Name, fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name), cd.Namespace).Set(float64(primary))
+	cr.weight.WithLabelValues(cd.Name, cd.Spec.TargetRef.Name, cd.Namespace).Set(float64(canary))
 }
 
 // IncSuccesses increments the total number of canary successes
@@ -184,6 +184,25 @@ func (cr *Recorder) IncSuccesses(labels CanaryMetricLabels) {
 // IncFailures increments the total number of canary failures
 func (cr *Recorder) IncFailures(labels CanaryMetricLabels) {
 	cr.failures.WithLabelValues(labels.Values()...).Inc()
+}
+
+// DeleteFor removes all per-canary metric series matching the given
+// name and namespace. Called when a Canary resource is deleted so that
+// stale series do not linger in the Prometheus registry.
+func (cr *Recorder) DeleteFor(name, namespace string) {
+	labels := prometheus.Labels{"name": name, "namespace": namespace}
+	cr.duration.DeletePartialMatch(labels)
+	cr.status.DeletePartialMatch(labels)
+	cr.weight.DeletePartialMatch(labels)
+	cr.analysis.DeletePartialMatch(labels)
+	cr.successes.DeletePartialMatch(labels)
+	cr.failures.DeletePartialMatch(labels)
+}
+
+// DeleteTotalFor removes the per-namespace canary_total series. Called
+// once a namespace no longer contains any Canary resources.
+func (cr *Recorder) DeleteTotalFor(namespace string) {
+	cr.total.DeleteLabelValues(namespace)
 }
 
 // GetStatusMetric returns the status metric

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -39,6 +39,9 @@ const (
 
 // CanaryMetricLabels holds labels for canary metrics
 type CanaryMetricLabels struct {
+	// Canary is the name of the Canary resource
+	Canary string
+	// Name is the name of the target workload (spec.targetRef.name)
 	Name               string
 	Namespace          string
 	DeploymentStrategy string
@@ -47,7 +50,7 @@ type CanaryMetricLabels struct {
 
 // Values returns label values as a slice for Prometheus metrics
 func (c CanaryMetricLabels) Values() []string {
-	return []string{c.Name, c.Namespace, c.DeploymentStrategy, c.AnalysisStatus}
+	return []string{c.Canary, c.Name, c.Namespace, c.DeploymentStrategy, c.AnalysisStatus}
 }
 
 // Recorder records the canary analysis as Prometheus metrics
@@ -75,7 +78,7 @@ func NewRecorder(controller string, register bool) Recorder {
 		Name:      "canary_duration_seconds",
 		Help:      "Seconds spent performing canary analysis.",
 		Buckets:   prometheus.DefBuckets,
-	}, []string{"name", "namespace"})
+	}, []string{"canary", "name", "namespace"})
 
 	total := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
@@ -88,31 +91,31 @@ func NewRecorder(controller string, register bool) Recorder {
 		Subsystem: controller,
 		Name:      "canary_status",
 		Help:      "Last canary analysis result",
-	}, []string{"name", "namespace"})
+	}, []string{"canary", "name", "namespace"})
 
 	weight := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
 		Name:      "canary_weight",
 		Help:      "The virtual service destination weight current value",
-	}, []string{"name", "workload", "namespace"})
+	}, []string{"canary", "workload", "namespace"})
 
 	analysis := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
 		Name:      "canary_metric_analysis",
 		Help:      "Last canary analysis result per metric",
-	}, []string{"name", "namespace", "metric"})
+	}, []string{"canary", "name", "namespace", "metric"})
 
 	successes := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: controller,
 		Name:      "canary_successes_total",
 		Help:      "Total number of canary successes",
-	}, []string{"name", "namespace", "deployment_strategy", "analysis_status"})
+	}, []string{"canary", "name", "namespace", "deployment_strategy", "analysis_status"})
 
 	failures := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: controller,
 		Name:      "canary_failures_total",
 		Help:      "Total number of canary failures",
-	}, []string{"name", "namespace", "deployment_strategy", "analysis_status"})
+	}, []string{"canary", "name", "namespace", "deployment_strategy", "analysis_status"})
 
 	if register {
 		prometheus.MustRegister(info)
@@ -144,7 +147,7 @@ func (cr *Recorder) SetInfo(version string, meshProvider string) {
 
 // SetDuration sets the time spent in seconds performing canary analysis
 func (cr *Recorder) SetDuration(cd *flaggerv1.Canary, duration time.Duration) {
-	cr.duration.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace).Observe(duration.Seconds())
+	cr.duration.WithLabelValues(cd.Name, cd.Spec.TargetRef.Name, cd.Namespace).Observe(duration.Seconds())
 }
 
 // SetTotal sets the total number of canaries per namespace
@@ -153,7 +156,7 @@ func (cr *Recorder) SetTotal(namespace string, total int) {
 }
 
 func (cr *Recorder) SetAnalysis(cd *flaggerv1.Canary, metricTemplateName string, val float64) {
-	cr.analysis.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace, metricTemplateName).Set(val)
+	cr.analysis.WithLabelValues(cd.Name, cd.Spec.TargetRef.Name, cd.Namespace, metricTemplateName).Set(val)
 }
 
 // SetStatus sets the last known canary analysis status
@@ -167,7 +170,7 @@ func (cr *Recorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.CanaryPhase)
 	default:
 		status = 1
 	}
-	cr.status.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace).Set(float64(status))
+	cr.status.WithLabelValues(cd.Name, cd.Spec.TargetRef.Name, cd.Namespace).Set(float64(status))
 }
 
 // SetWeight sets the weight values for primary and canary destinations
@@ -190,7 +193,7 @@ func (cr *Recorder) IncFailures(labels CanaryMetricLabels) {
 // name and namespace. Called when a Canary resource is deleted so that
 // stale series do not linger in the Prometheus registry.
 func (cr *Recorder) DeleteFor(name, namespace string) {
-	labels := prometheus.Labels{"name": name, "namespace": namespace}
+	labels := prometheus.Labels{"canary": name, "namespace": namespace}
 	cr.duration.DeletePartialMatch(labels)
 	cr.status.DeletePartialMatch(labels)
 	cr.weight.DeletePartialMatch(labels)

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -62,7 +62,7 @@ func TestRecorder_GetterMethodsWithData(t *testing.T) {
 			name:       "SetAndGetStatus",
 			setupFunc:  func(r Recorder) { r.SetStatus(canary, flaggerv1.CanaryPhaseSucceeded) },
 			getterFunc: func(r Recorder) interface{} { return r.GetStatusMetric() },
-			labels:     []string{"podinfo", "default"},
+			labels:     []string{"podinfo", "podinfo", "default"},
 			expected:   1.0,
 			checkValue: true,
 		},
@@ -86,27 +86,27 @@ func TestRecorder_GetterMethodsWithData(t *testing.T) {
 			name:       "SetAndGetAnalysis",
 			setupFunc:  func(r Recorder) { r.SetAnalysis(canary, "request-success-rate", 99.5) },
 			getterFunc: func(r Recorder) interface{} { return r.GetAnalysisMetric() },
-			labels:     []string{"podinfo", "default", "request-success-rate"},
+			labels:     []string{"podinfo", "podinfo", "default", "request-success-rate"},
 			expected:   99.5,
 			checkValue: true,
 		},
 		{
 			name: "IncAndGetSuccesses",
 			setupFunc: func(r Recorder) {
-				r.IncSuccesses(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+				r.IncSuccesses(CanaryMetricLabels{Canary: "podinfo", Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
 			},
 			getterFunc: func(r Recorder) interface{} { return r.GetSuccessesMetric() },
-			labels:     []string{"podinfo", "default", "canary", "completed"},
+			labels:     []string{"podinfo", "podinfo", "default", "canary", "completed"},
 			expected:   1.0,
 			checkValue: true,
 		},
 		{
 			name: "IncAndGetFailures",
 			setupFunc: func(r Recorder) {
-				r.IncFailures(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+				r.IncFailures(CanaryMetricLabels{Canary: "podinfo", Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
 			},
 			getterFunc: func(r Recorder) interface{} { return r.GetFailuresMetric() },
-			labels:     []string{"podinfo", "default", "canary", "completed"},
+			labels:     []string{"podinfo", "podinfo", "default", "canary", "completed"},
 			expected:   1.0,
 			checkValue: true,
 		},
@@ -162,8 +162,8 @@ func TestRecorder_DeleteFor(t *testing.T) {
 	recorder.SetWeight(canary, 90, 10)
 	recorder.SetAnalysis(canary, "request-success-rate", 99.5)
 	recorder.SetDuration(canary, time.Second)
-	recorder.IncSuccesses(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
-	recorder.IncFailures(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+	recorder.IncSuccesses(CanaryMetricLabels{Canary: "podinfo", Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+	recorder.IncFailures(CanaryMetricLabels{Canary: "podinfo", Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
 
 	recorder.SetStatus(other, flaggerv1.CanaryPhaseSucceeded)
 	recorder.SetWeight(other, 100, 0)
@@ -178,7 +178,7 @@ func TestRecorder_DeleteFor(t *testing.T) {
 	assert.Equal(t, 0, testutil.CollectAndCount(recorder.GetFailuresMetric(), "test_delete_canary_failures_total"))
 
 	// unrelated canary's series must be preserved
-	assert.Equal(t, float64(1), testutil.ToFloat64(recorder.GetStatusMetric().WithLabelValues("keep-me", "default")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(recorder.GetStatusMetric().WithLabelValues("keep-me", "keep-me", "default")))
 	assert.Equal(t, float64(100), testutil.ToFloat64(recorder.GetWeightMetric().WithLabelValues("keep-me", "keep-me-primary", "default")))
 }
 

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -131,3 +131,67 @@ func TestRecorder_GetterMethodsWithData(t *testing.T) {
 		})
 	}
 }
+
+func TestRecorder_DeleteFor(t *testing.T) {
+	recorder := NewRecorder("test_delete", false)
+
+	canary := &flaggerv1.Canary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "podinfo",
+			Namespace: "default",
+		},
+		Spec: flaggerv1.CanarySpec{
+			TargetRef: flaggerv1.LocalObjectReference{
+				Name: "podinfo",
+			},
+		},
+	}
+	other := &flaggerv1.Canary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keep-me",
+			Namespace: "default",
+		},
+		Spec: flaggerv1.CanarySpec{
+			TargetRef: flaggerv1.LocalObjectReference{
+				Name: "keep-me",
+			},
+		},
+	}
+
+	recorder.SetStatus(canary, flaggerv1.CanaryPhaseSucceeded)
+	recorder.SetWeight(canary, 90, 10)
+	recorder.SetAnalysis(canary, "request-success-rate", 99.5)
+	recorder.SetDuration(canary, time.Second)
+	recorder.IncSuccesses(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+	recorder.IncFailures(CanaryMetricLabels{Name: "podinfo", Namespace: "default", DeploymentStrategy: "canary", AnalysisStatus: "completed"})
+
+	recorder.SetStatus(other, flaggerv1.CanaryPhaseSucceeded)
+	recorder.SetWeight(other, 100, 0)
+
+	recorder.DeleteFor("podinfo", "default")
+
+	// only the unrelated "keep-me" canary should have series remaining
+	assert.Equal(t, 1, testutil.CollectAndCount(recorder.GetStatusMetric(), "test_delete_canary_status"))
+	assert.Equal(t, 2, testutil.CollectAndCount(recorder.GetWeightMetric(), "test_delete_canary_weight"))
+	assert.Equal(t, 0, testutil.CollectAndCount(recorder.GetAnalysisMetric(), "test_delete_canary_metric_analysis"))
+	assert.Equal(t, 0, testutil.CollectAndCount(recorder.GetSuccessesMetric(), "test_delete_canary_successes_total"))
+	assert.Equal(t, 0, testutil.CollectAndCount(recorder.GetFailuresMetric(), "test_delete_canary_failures_total"))
+
+	// unrelated canary's series must be preserved
+	assert.Equal(t, float64(1), testutil.ToFloat64(recorder.GetStatusMetric().WithLabelValues("keep-me", "default")))
+	assert.Equal(t, float64(100), testutil.ToFloat64(recorder.GetWeightMetric().WithLabelValues("keep-me", "keep-me-primary", "default")))
+}
+
+func TestRecorder_DeleteTotalFor(t *testing.T) {
+	recorder := NewRecorder("test_delete_total", false)
+
+	recorder.SetTotal("ns-a", 2)
+	recorder.SetTotal("ns-b", 1)
+
+	assert.Equal(t, 2, testutil.CollectAndCount(recorder.GetTotalMetric(), "test_delete_total_canary_total"))
+
+	recorder.DeleteTotalFor("ns-a")
+
+	assert.Equal(t, 1, testutil.CollectAndCount(recorder.GetTotalMetric(), "test_delete_total_canary_total"))
+	assert.Equal(t, float64(1), testutil.ToFloat64(recorder.GetTotalMetric().WithLabelValues("ns-b")))
+}


### PR DESCRIPTION
**Summary**

fixes #1960

~Three~ Four related fixes to Flagger's Prometheus metrics:

1. **`flagger_canary_*` metrics gain a `canary` label.** The `canary` label will be the Canary resource name (`cd.Name`) and will be consistent across all metrics, which allows for a stable key to be used across all the metrics. Final result:
	| Metric | Labels (after) |
	|---|---|
	| `flagger_canary_status` | `canary`, `name`, `namespace` |
	| `flagger_canary_duration_seconds` | `canary`, `name`, `namespace` |
	| `flagger_canary_metric_analysis` | `canary`, `name`, `namespace`, `metric` |
	| `flagger_canary_weight` | `canary`, `workload`, `namespace` |
	| `flagger_canary_successes_total` | `canary`, `name`, `namespace`, `deployment_strategy`, `analysis_status` |
	| `flagger_canary_failures_total` | `canary`, `name`, `namespace`, `deployment_strategy`, `analysis_status` |

2. **Per-canary series are cleaned up on Canary deletion.** The controller's `DeleteFunc` only removed the canary from an in-memory job map; the Prometheus series lived for the process lifetime. A new `Recorder.DeleteFor(name, namespace)` calls `DeletePartialMatch({name, namespace})` on every per-canary vec (`duration`, `status`, `weight`, `analysis`, `successes`, `failures`) and is invoked from `DeleteFunc`.
3. **`flagger_canary_total` is cleaned up when a namespace no longer has any canaries.** `scheduleCanaries` previously only wrote totals for namespaces that currently held canaries, so a namespace that dropped to zero kept its last value forever. The controller now tracks reported namespaces and calls `Recorder.DeleteTotalFor(namespace)` for any that fall out on the next tick.
4. Emit `flagger_canary_weight` in steady state so it survives restarts and appears right after initialization — previously it was only set while a canary was progressing, leaving initialized/succeeded canaries (and everything after a controller restart) without a weight series until the next rollout. The `!shouldAdvance` path now also reads the current routes and calls `SetWeight`, with a regression test asserting the gauge is present for a freshly-initialized canary.

**Behaviour changes to be aware of**

- `canary` label is added to all `flagger_canary_*` metrics
- Deleting a Canary now removes its counter/gauge series immediately, including `flagger_canary_successes_total` and `flagger_canary_failures_total`.
- `flagger_canary_weight` metric is populated as soon as the canary is initialized and when flagger restarts.

**Tests**

- Updated `scheduler_metrics_test.go` weight assertions for the new label.
- Added `TestRecorder_DeleteFor` and `TestRecorder_DeleteTotalFor` in `pkg/metrics/recorder_test.go`.
- `go test ./pkg/metrics/... ./pkg/controller/...` passes.
