### PR TITLE
fix: preserve localityLbSetting.enabled=false in Istio destination rules

### DIFF
--- a/pkg/apis/istio/v1beta1/destination_rule.go
+++ b/pkg/apis/istio/v1beta1/destination_rule.go
@@ -368,7 +368,10 @@ type LocalityLbSetting struct {
 	FailoverPriority []string `json:"failover_priority,omitempty"`
 	// enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
 	// e.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh wide settings is.
-	Enabled bool `json:"enabled,omitempty"`
+	// This is a pointer so that an explicit `enabled: false` is preserved when the
+	// DestinationRule is generated (a plain bool with omitempty would drop it and
+	// Istio would fall back to the mesh-wide default, which is enabled).
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // Describes how traffic originating in the 'from' zone or sub-zone is

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -702,6 +702,11 @@ func (in *LocalityLbSetting) DeepCopyInto(out *LocalityLbSetting) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/router/istio_test.go
+++ b/pkg/router/istio_test.go
@@ -1077,3 +1077,47 @@ func TestIstioRouter_GetRoutesTCP(t *testing.T) {
 	// A TCP Canary resource has mirroring disabled
 	assert.False(t, m)
 }
+
+func TestIstioRouter_LocalityLbSettingEnabledFalse(t *testing.T) {
+	enabled := false
+	canary := newTestCanary()
+	canary.Spec.Service.TrafficPolicy = &istiov1beta1.TrafficPolicy{
+		LoadBalancer: &istiov1beta1.LoadBalancerSettings{
+			Simple: istiov1beta1.SimpleLB("RANDOM"),
+			LocalityLbSetting: &istiov1beta1.LocalityLbSetting{
+				Enabled: &enabled,
+			},
+		},
+		OutlierDetection: &istiov1beta1.OutlierDetection{
+			ConsecutiveErrors: 5,
+			Interval:          "10s",
+			BaseEjectionTime:  "10s",
+		},
+	}
+	mocks := newFixture(canary)
+	router := &IstioRouter{
+		logger:        mocks.logger,
+		flaggerClient: mocks.flaggerClient,
+		istioClient:   mocks.meshClient,
+		kubeClient:    mocks.kubeClient,
+	}
+
+	err := router.Reconcile(mocks.canary)
+	require.NoError(t, err)
+
+	for _, name := range []string{"podinfo-primary", "podinfo-canary"} {
+		dr, err := mocks.meshClient.NetworkingV1beta1().DestinationRules("default").Get(context.TODO(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, dr.Spec.TrafficPolicy)
+		require.NotNil(t, dr.Spec.TrafficPolicy.LoadBalancer)
+		require.NotNil(t, dr.Spec.TrafficPolicy.LoadBalancer.LocalityLbSetting)
+		require.NotNil(t, dr.Spec.TrafficPolicy.LoadBalancer.LocalityLbSetting.Enabled)
+		assert.False(t, *dr.Spec.TrafficPolicy.LoadBalancer.LocalityLbSetting.Enabled)
+
+		// an explicit `enabled: false` must survive serialization, otherwise Istio
+		// falls back to the mesh-wide default (enabled) when outlierDetection is set
+		b, err := json.Marshal(dr.Spec.TrafficPolicy.LoadBalancer)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"localityLbSetting":{"enabled":false}`)
+	}
+}


### PR DESCRIPTION
Related #1719

## Summary
`LocalityLbSetting.Enabled` is a plain bool with omitempty, so an explicit `enabled: false` in `trafficPolicy.loadBalancer.localityLbSetting` is dropped from the generated DestinationRules (`localityLbSetting: {}`).

Istio treats an unset enabled as the mesh-wide default (enabled), and locality failover is activated whenever outlierDetection is set. Users who set `enabled: false` to keep traffic evenly distributed across zones silently end up with zone-prioritized routing.

## Changes

- Changed `LocalityLbSetting.Enabled` from `bool` to `*bool` so that `false` round-trips into the DestinationRule (regenerated deepcopy)
- Added a regression test (`TestIstioRouter_LocalityLbSettingEnabledFalse`)
- No CRD change: `enabled` is already declared as `boolean`

## Testing
Verified locally against kind (Kubernetes 1.35.1) with Istio 1.29.2, using a Flagger image built from this branch.
A Canary with:
```yaml
trafficPolicy:
  loadBalancer:
    simple: RANDOM
    localityLbSetting:
      enabled: false
  outlierDetection:
    consecutive5xxErrors: 5
    interval: 10s
    baseEjectionTime: 10s
```

With v1.44.0 the generated `podinfo-primary` / `podinfo-canary` DestinationRules lose the flag:
```yaml
  trafficPolicy:
    loadBalancer:
      localityLbSetting: {}
      simple: RANDOM
```

With this branch both DestinationRules keep it:
```yaml
  trafficPolicy:
    loadBalancer:
      localityLbSetting:
        enabled: false
      simple: RANDOM
    outlierDetection:
      baseEjectionTime: 10s
      consecutive5xxErrors: 5
      interval: 10s
```

Also confirmed on the client sidecar (`pilot-agent request GET clusters`, two zone-labelled nodes) that the endpoints are no longer split into `priority: 0/1` by zone once the flag reaches Istio.
